### PR TITLE
Support for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,15 +21,14 @@ jobs:
           - '1.23'
         os:
           - ubuntu-latest
-          # TODO: add support for windows then we can remove the comment
-          # - windows-latest
+          - windows-latest
 
     permissions:
       contents: read
 
     steps:
     - name: Set up Go ${{ matrix.go }}
-      uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
         go-version: ${{ matrix.go }}
         check-latest: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set up Go 1.23
-      uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
         go-version: '1.23'
         check-latest: true

--- a/exec/builder_unix_test.go
+++ b/exec/builder_unix_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package exec
 
 import (
@@ -201,64 +203,6 @@ func TestCommandBuilder_Start(t *testing.T) {
 				if p.Result() != test.results[i] {
 					t.Errorf("unexpected proc result: %s", p.Result())
 				}
-			}
-		})
-	}
-}
-
-func TestCommandBuilder_Pipe(t *testing.T) {
-	tests := []struct {
-		name         string
-		commands     []string
-		results      []string
-		expectedCmds int
-		expectedErrs int
-	}{
-		{
-			name:         "one command",
-			commands:     []string{"echo 'hello world'"},
-			results:      []string{"hello world"},
-			expectedCmds: 1,
-		},
-		{
-			name:         "two commands",
-			commands:     []string{"echo -n 'hello world'", "wc -m"},
-			results:      []string{"11"},
-			expectedCmds: 2,
-		},
-		{
-			name:         "three commands",
-			commands:     []string{"echo -n 'hello world'", "grep world", "wc -w"},
-			results:      []string{"2"},
-			expectedCmds: 3,
-		},
-		{
-			name:         "three commands with 1 err",
-			commands:     []string{"echo -n 'hello world'", "foo", "wc -w"},
-			results:      []string{"2"},
-			expectedCmds: 2,
-			expectedErrs: 1,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			c := Commands(test.commands...).Pipe()
-			if len(c.Procs()) != test.expectedCmds {
-				t.Errorf("expecting %d procs to run, got %d", test.expectedCmds, len(c.Procs()))
-			}
-
-			if test.expectedErrs != len(c.ErrProcs()) {
-				t.Logf("Errors: %#v", c.ErrStrings())
-				t.Fatalf("expecting %d errors, but got %d", test.expectedErrs, len(c.ErrProcs()))
-			}
-			// for pipe, only check last result
-			p := c.LastProc()
-			if p.Err() != nil && test.expectedErrs == 0 {
-				t.Fatalf("last proc in pipe failed: %s", p.Err())
-			}
-			if p.Err() == nil && p.Result() != test.results[0] {
-				t.Errorf("unexpected proc result: %s", p.Result())
 			}
 		})
 	}

--- a/exec/builder_windows_test.go
+++ b/exec/builder_windows_test.go
@@ -1,0 +1,271 @@
+//go:build windows
+
+package exec
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestCommandBuilder_Run(t *testing.T) {
+	tests := []struct {
+		name         string
+		commands     []string
+		results      []string
+		expectedCmds int
+		expectedErrs int
+		policy       CommandPolicy
+	}{
+		{
+			name: "zero procs",
+		},
+		{
+			name: "no error in procs",
+			commands: []string{
+				`powershell.exe -c "Write-Host 'hello world'"`,
+				`powershell.exe -c "Get-Date -UFormat '+%Y-%m-%d'"`,
+				`powershell.exe -c "dir"`,
+			},
+			results: []string{
+				"hello world",
+				Run(`powershell.exe -c "Get-Date -UFormat '+%Y-%m-%d'"`),
+				Run(`powershell.exe -c "dir"`),
+			},
+			expectedCmds: 3,
+		},
+		{
+			name: "continue on 1 error",
+			commands: []string{
+				`foobar`,
+				`powershell.exe -c "Write-Host 'hello world'"`,
+				`powershell.exe -c "Get-Date -UFormat '+%Y-%m-%d'"`,
+				`powershell.exe -c "dir"`,
+			},
+			results: []string{
+				Run(`foobar`),
+				"hello world",
+				Run(`powershell.exe -c "Get-Date -UFormat '+%Y-%m-%d'"`),
+				Run(`powershell.exe -c "dir"`),
+			},
+			expectedCmds: 4,
+			expectedErrs: 1,
+		},
+		{
+			name: "continue on 2 error",
+			commands: []string{
+				`foobar`,
+				`powershell.exe -c "Write-Host 'hello world'"`,
+				`daftpunk`,
+				`powershell.exe -c "Get-Date -UFormat '+%Y-%m-%d'"`,
+				`powershell.exe -c "dir"`,
+			},
+			results: []string{
+				Run(`foobar`),
+				"hello world",
+				Run(`daftpunk`),
+				Run(`powershell.exe -c "Get-Date -UFormat '+%Y-%m-%d'"`),
+				Run(`powershell.exe -c "dir"`),
+			},
+			expectedCmds: 5,
+			expectedErrs: 2,
+		},
+		{
+			name: "exit on 1 error",
+			commands: []string{
+				`powershell.exe -c "Write-Host 'hello world'"`,
+				`daftpunk`,
+				`powershell.exe -c "Get-Date -UFormat '+%Y-%m-%d'"`,
+				`powershell.exe -c "dir"`,
+			},
+			results: []string{
+				"hello world",
+				Run(`daftpunk`),
+				Run(`powershell.exe -c "Get-Date -UFormat '+%Y-%m-%d'"`),
+				Run(`powershell.exe -c "dir"`),
+			},
+			expectedCmds: 2,
+			expectedErrs: 1,
+			policy:       ExitOnErrPolicy,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := Commands(test.commands...).WithPolicy(test.policy).Run()
+			if len(c.Procs()) != test.expectedCmds {
+				t.Errorf("expecting %d procs to run, got %d", test.expectedCmds, len(c.Procs()))
+			}
+
+			if len(c.ErrProcs()) != test.expectedErrs {
+				fmt.Printf("c.ErrProcs(): %v\n", c.ErrProcs()[0].Result())
+				t.Errorf("expecting %d procs errors, got %d", test.expectedErrs, len(c.ErrProcs()))
+			}
+
+			for i, p := range c.Procs() {
+				if p.Result() != test.results[i] {
+					t.Errorf("unexpected proc result: %s", p.Result())
+				}
+			}
+		})
+	}
+}
+
+func TestCommandBuilder_Start(t *testing.T) {
+	tests := []struct {
+		name         string
+		commands     []string
+		results      []string
+		expectedCmds int
+		expectedErrs int
+		policy       CommandPolicy
+	}{
+		{
+			name: "zero procs",
+		},
+		{
+			name: "no error in procs",
+			commands: []string{
+				`powershell.exe -c "Write-Host 'hello world'"`,
+				`powershell.exe -c "Get-Date -UFormat '+%Y-%m-%d'"`,
+				`powershell.exe -c "dir"`,
+			},
+			results: []string{
+				"hello world",
+				Run(`powershell.exe -c "Get-Date -UFormat '+%Y-%m-%d'"`),
+				Run(`powershell.exe -c "dir"`),
+			},
+			expectedCmds: 3,
+		},
+		{
+			name: "continue on 1 error",
+			commands: []string{
+				`foobar`,
+				`powershell.exe -c "Write-Host 'hello world'"`,
+				`powershell.exe -c "Get-Date -UFormat '+%Y-%m-%d'"`,
+				`powershell.exe -c "dir"`,
+			},
+			results: []string{
+				Run(`foobar`),
+				"hello world",
+				Run(`powershell.exe -c "Get-Date -UFormat '+%Y-%m-%d'"`),
+				Run(`powershell.exe -c "dir"`),
+			},
+			expectedCmds: 4,
+			expectedErrs: 1,
+		},
+		{
+			name: "stop on errors",
+			commands: []string{
+				`powershell.exe -c "Write-Host 'hello world'"`,
+				`daftpunk`,
+				`powershell.exe -c "Get-Date -UFormat '+%Y-%m-%d'"`,
+				`powershell.exe -c "dir"`,
+			},
+			results: []string{
+				"hello world",
+				Run(`daftpunk`),
+				Run(`powershell.exe -c "Get-Date -UFormat '+%Y-%m-%d'"`),
+				Run(`powershell.exe -c "dir"`),
+			},
+			expectedCmds: 2,
+			expectedErrs: 1,
+			policy:       ExitOnErrPolicy,
+		},
+
+		// concurrent
+		{
+			name: "concurrent no errors",
+			commands: []string{
+				`powershell.exe -c "Write-Host 'hello world'"`,
+				`powershell.exe -c "Get-Date -UFormat '+%Y-%m-%d'"`,
+				`powershell.exe -c "dir"`,
+			},
+			results: []string{
+				"hello world",
+				Run(`powershell.exe -c "Get-Date -UFormat '+%Y-%m-%d'"`),
+				Run(`powershell.exe -c "dir"`),
+			},
+			expectedCmds: 3,
+			policy:       ConcurrentExecPolicy,
+		},
+		{
+			name: "concurrent on 1 error",
+			commands: []string{
+				`foobar`,
+				`powershell.exe -c "Write-Host 'hello world'"`,
+				`powershell.exe -c "Get-Date -UFormat '+%Y-%m-%d'"`,
+				`powershell.exe -c "dir"`,
+			},
+			results: []string{
+				Run(`foobar`),
+				"hello world",
+				Run(`powershell.exe -c "Get-Date -UFormat '+%Y-%m-%d'"`),
+				Run(`powershell.exe -c "dir"`),
+			},
+			expectedCmds: 4,
+			expectedErrs: 1,
+			policy:       ConcurrentExecPolicy,
+		},
+		{
+			name: "concurrent on 2 errors",
+			commands: []string{
+				`foobar`,
+				`powershell.exe -c "Write-Host 'hello world'"`,
+				`daftpunk`,
+				`powershell.exe -c "Get-Date -UFormat '+%Y-%m-%d'"`,
+				`powershell.exe -c "dir"`,
+			},
+			results: []string{
+				Run(`foobar`),
+				"hello world",
+				Run(`daftpunk`),
+				Run(`powershell.exe -c "Get-Date -UFormat '+%Y-%m-%d'"`),
+				Run(`powershell.exe -c "dir"`),
+			},
+			expectedCmds: 5,
+			expectedErrs: 2,
+			policy:       ConcurrentExecPolicy,
+		},
+		{
+			name: "concurrent on errors",
+			commands: []string{
+				`powershell.exe -c "Write-Host 'hello world'"`,
+				`daftpunk`,
+				`powershell.exe -c "Get-Date -UFormat '+%Y-%m-%d'"`,
+				`powershell.exe -c "dir"`,
+			},
+			results: []string{
+				"hello world",
+				Run(`daftpunk`),
+				Run(`powershell.exe -c "Get-Date -UFormat '+%Y-%m-%d'"`),
+				Run(`powershell.exe -c "dir"`),
+			},
+			expectedCmds: 4,
+			expectedErrs: 1,
+			policy:       ExitOnErrPolicy | ConcurrentExecPolicy, // ExitOnErr is ignored when concurrent
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := Commands(test.commands...).WithPolicy(test.policy).Start()
+			if len(result.Procs()) != 0 {
+				t.Fatal("expecting 0 completed processes at this point")
+			}
+			result = result.Wait()
+			if len(result.Procs()) != test.expectedCmds {
+				t.Errorf("expecting %d procs to run, got %d", test.expectedCmds, len(result.Procs()))
+			}
+
+			if len(result.ErrProcs()) != test.expectedErrs {
+				t.Errorf("expecting %d procs errors, got %d", test.expectedErrs, len(result.ErrProcs()))
+			}
+
+			for i, p := range result.Procs() {
+				if p.Result() != test.results[i] {
+					t.Errorf("unexpected proc result: %s", p.Result())
+				}
+			}
+		})
+	}
+}

--- a/exec/pipe_unix.go
+++ b/exec/pipe_unix.go
@@ -1,0 +1,81 @@
+//go:build !windows
+
+package exec
+
+import "errors"
+
+// Pipe executes each command serially chaining the combinedOutput
+// of previous command to the input Pipe of next command.
+func (cb *CommandBuilder) Pipe() *PipedCommandResult {
+	if cb.err != nil {
+		return &PipedCommandResult{err: cb.err}
+	}
+
+	result := cb.connectProcPipes()
+
+	// check for structural errors
+	if result.err != nil {
+		return result
+	}
+
+	// start each process (but, not wait for result)
+	// to ensure data flow between successive processes start
+	for _, p := range cb.procs {
+		result.procs = append(result.procs, p)
+		if err := p.Start().Err(); err != nil {
+			result.errProcs = append(result.errProcs, p)
+			return result
+		}
+	}
+
+	// wait and access processes result
+	for _, p := range cb.procs {
+		if err := p.Wait().Err(); err != nil {
+			result.errProcs = append(result.errProcs, p)
+			break
+		}
+	}
+
+	return result
+}
+
+// connectProcPipes connects the output of each process to the input of the next process in the chain.
+// It returns a PipedCommandResult containing the connected processes and any errors encountered.
+func (cb *CommandBuilder) connectProcPipes() *PipedCommandResult {
+	var result PipedCommandResult
+
+	procLen := len(cb.procs)
+	if procLen == 0 {
+		return &PipedCommandResult{err: errors.New("no processes to connect")}
+	}
+
+	// wire last proc to combined output
+	last := procLen - 1
+	result.lastProc = cb.procs[last]
+
+	// setup standard output/err of last proc in pipe
+	result.lastProc.cmd.Stdout = cb.stdout
+	if cb.stdout == nil {
+		result.lastProc.cmd.Stdout = result.lastProc.result
+	}
+
+	// Wire standard error of last proc in pipe
+	result.lastProc.cmd.Stderr = cb.stderr
+	if cb.stderr == nil {
+		result.lastProc.cmd.Stderr = result.lastProc.result
+	}
+
+	// setup pipes for inner procs in the pipe chain
+	result.lastProc.cmd.Stdout = result.lastProc.result
+	for i, p := range cb.procs[:last] {
+		pipeout, err := p.cmd.StdoutPipe()
+		if err != nil {
+			p.err = err
+			return &PipedCommandResult{err: err, errProcs: []*Proc{p}}
+		}
+
+		cb.procs[i+1].cmd.Stdin = pipeout
+	}
+
+	return &result
+}

--- a/exec/pipe_unix_test.go
+++ b/exec/pipe_unix_test.go
@@ -1,0 +1,63 @@
+//go:build !windows
+
+package exec
+
+import "testing"
+
+func TestCommandBuilder_Pipe(t *testing.T) {
+	tests := []struct {
+		name         string
+		commands     []string
+		results      []string
+		expectedCmds int
+		expectedErrs int
+	}{
+		{
+			name:         "one command",
+			commands:     []string{"echo 'hello world'"},
+			results:      []string{"hello world"},
+			expectedCmds: 1,
+		},
+		{
+			name:         "two commands",
+			commands:     []string{"echo -n 'hello world'", "wc -m"},
+			results:      []string{"11"},
+			expectedCmds: 2,
+		},
+		{
+			name:         "three commands",
+			commands:     []string{"echo -n 'hello world'", "grep world", "wc -w"},
+			results:      []string{"2"},
+			expectedCmds: 3,
+		},
+		{
+			name:         "three commands with 1 err",
+			commands:     []string{"echo -n 'hello world'", "foo", "wc -w"},
+			results:      []string{"2"},
+			expectedCmds: 2,
+			expectedErrs: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := Commands(test.commands...).Pipe()
+			if len(c.Procs()) != test.expectedCmds {
+				t.Errorf("expecting %d procs to run, got %d", test.expectedCmds, len(c.Procs()))
+			}
+
+			if test.expectedErrs != len(c.ErrProcs()) {
+				t.Logf("Errors: %#v", c.ErrStrings())
+				t.Fatalf("expecting %d errors, but got %d", test.expectedErrs, len(c.ErrProcs()))
+			}
+			// for pipe, only check last result
+			p := c.LastProc()
+			if p.Err() != nil && test.expectedErrs == 0 {
+				t.Fatalf("last proc in pipe failed: %s", p.Err())
+			}
+			if p.Err() == nil && p.Result() != test.results[0] {
+				t.Errorf("unexpected proc result: %s", p.Result())
+			}
+		})
+	}
+}

--- a/exec/pipe_windows.go
+++ b/exec/pipe_windows.go
@@ -1,0 +1,80 @@
+//go:build windows
+
+package exec
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+)
+
+// Pipe executes each Windows command serially. Windows, however, does not support
+// OS pipes like {Li|U}nix. Instead, pipes use a single command string, with | delimiters,
+// passed to powershell. So prior to calling Pipe(), call CommandBulider.WithShell()
+// to specify "powershell.exe -c" as the shell.
+// (See tests for examples.)
+func (cb *CommandBuilder) Pipe() *PipedCommandResult {
+	if cb.err != nil {
+		return &PipedCommandResult{err: cb.err}
+	}
+
+	result := new(PipedCommandResult)
+
+	// setup a single command string with pipe delimiters
+	cmd := strings.Join(cb.cmdStrings, " | ")
+
+	// Prepend shell command if specified
+	if cb.shellStr != "" {
+		cmd = cb.shellStr + " " + cmd
+	}
+
+	proc := NewProcWithVars(cmd, cb.vars)
+	result.procs = append(result.procs, proc)
+	result.lastProc = proc
+
+	// execute the piped commands
+	if err := cb.runCommand(proc); err != nil {
+		return &PipedCommandResult{err: err, errProcs: []*Proc{proc}}
+	}
+
+	return result
+}
+
+// connectProcPipes connects the output of each process to the input of the next process in the chain.
+// It returns a PipedCommandResult containing the connected processes and any errors encountered.
+func (cb *CommandBuilder) connectProcPipes() *PipedCommandResult {
+	var result PipedCommandResult
+
+	procLen := len(cb.procs)
+	if procLen == 0 {
+		return &PipedCommandResult{err: errors.New("no processes to connect")}
+	}
+
+	// wire last proc to combined output
+	last := procLen - 1
+	result.lastProc = cb.procs[last]
+
+	// setup standard output/err for last proc in pipe
+	result.lastProc.cmd.Stdout = cb.stdout
+	if cb.stdout == nil {
+		result.lastProc.cmd.Stdout = result.lastProc.result
+	}
+
+	// Wire the remainder procs
+	result.lastProc.cmd.Stderr = cb.stderr
+	if cb.stderr == nil {
+		result.lastProc.cmd.Stderr = result.lastProc.result
+	}
+
+	// exec.Command.StdoutPipe() uses OS pipes, which are not supported on Windows.
+	// Instead, this uses an in-memory pipe and set the command's stdin to the write end of the pipe.
+	result.lastProc.cmd.Stdout = result.lastProc.result
+	for i := range cb.procs[:last] {
+		// Create an in-memory pipe for the command's stdout
+		pipe := new(bytes.Buffer)
+		cb.procs[i].cmd.Stdout = pipe
+		cb.procs[i+1].cmd.Stdin = pipe
+	}
+
+	return &result
+}

--- a/exec/pipe_windows_test.go
+++ b/exec/pipe_windows_test.go
@@ -1,0 +1,57 @@
+//go:build windows
+
+package exec
+
+import "testing"
+
+func TestCommandBuilder_Pipe(t *testing.T) {
+	tests := []struct {
+		name         string
+		commands     []string
+		results      []string
+		expectedErrs int
+		shellCmd     string
+	}{
+		{
+			name:     "single command",
+			commands: []string{`powershell.exe -c "Write-Host -NoNewline 'hello world'"`},
+			results:  []string{"hello world"},
+		},
+		{
+			name:     "single command, set shell",
+			shellCmd: "powershell.exe -c",
+			commands: []string{`Write-Host -NoNewline 'hello world'`},
+			results:  []string{"hello world"},
+		},
+		{
+			name:     "count characters",
+			shellCmd: "powershell.exe -c",
+			commands: []string{`Write-Output 'Hello World!'`, `Measure-Object -Character -Line`, `Select-Object -ExpandProperty Characters`},
+			results:  []string{"11"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmds := Commands(test.commands...)
+			if test.shellCmd != "" {
+				cmds.WithShell(test.shellCmd)
+			}
+
+			c := cmds.Pipe()
+			if test.expectedErrs != len(c.ErrProcs()) {
+				t.Logf("Errors: %#v", c.ErrStrings())
+				t.Fatalf("expecting %d errors, but got %d", test.expectedErrs, len(c.ErrProcs()))
+			}
+
+			// for pipe, only check last result
+			p := c.LastProc()
+			if p.Err() != nil && test.expectedErrs == 0 {
+				t.Fatalf("last proc in pipe failed: %s", p.Err())
+			}
+			if p.Err() == nil && p.Result() != test.results[0] {
+				t.Errorf("unexpected proc result: %s", p.Result())
+			}
+		})
+	}
+}

--- a/exec/proc.go
+++ b/exec/proc.go
@@ -10,7 +10,6 @@ import (
 	"os/user"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/vladimirvivien/gexe/vars"
@@ -189,24 +188,7 @@ func (p *Proc) Start() *Proc {
 	}
 
 	// apply user id and user grp
-	var procCred *syscall.Credential
-	if p.userid != nil {
-		procCred = &syscall.Credential{
-			Uid: uint32(*p.userid),
-		}
-	}
-	if p.groupid != nil {
-		if procCred == nil {
-			procCred = new(syscall.Credential)
-		}
-		procCred.Uid = uint32(*p.groupid)
-	}
-	if procCred != nil {
-		if p.cmd.SysProcAttr == nil {
-			p.cmd.SysProcAttr = new(syscall.SysProcAttr)
-		}
-		p.cmd.SysProcAttr.Credential = procCred
-	}
+	p.applyCredentials()
 
 	if err := p.cmd.Start(); err != nil {
 		p.err = err

--- a/exec/proc_unix.go
+++ b/exec/proc_unix.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package exec
+
+import (
+	"syscall"
+)
+
+// applyCredentials applies the user and group IDs to the command.
+func (p *Proc) applyCredentials() {
+	// apply user id and user grp
+	var procCred *syscall.Credential
+	if p.userid != nil {
+		procCred = &syscall.Credential{
+			Uid: uint32(*p.userid),
+		}
+	}
+	if p.groupid != nil {
+		if procCred == nil {
+			procCred = new(syscall.Credential)
+		}
+		procCred.Gid = uint32(*p.groupid)
+	}
+	if procCred != nil {
+		if p.cmd.SysProcAttr == nil {
+			p.cmd.SysProcAttr = new(syscall.SysProcAttr)
+		}
+		p.cmd.SysProcAttr.Credential = procCred
+	}
+}

--- a/exec/proc_unix_test.go
+++ b/exec/proc_unix_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package exec
 
 import (

--- a/exec/proc_windows.go
+++ b/exec/proc_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package exec
+
+// applyCredentials is a no-op as this works vastly different on Windows.
+func (p *Proc) applyCredentials() {
+	// Windows doesn't support user/group IDs in the same way {Li|U}nix does.
+	// Windows impersonation will not be supported in this package a this time.
+}

--- a/exec/proc_windows_test.go
+++ b/exec/proc_windows_test.go
@@ -1,0 +1,654 @@
+//go:build windows
+
+package exec
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vladimirvivien/gexe/vars"
+)
+
+func TestNewProc(t *testing.T) {
+	tests := []struct {
+		name   string
+		cmdStr string
+		exec   func(*testing.T, string)
+	}{
+		{
+			name:   "access result",
+			cmdStr: `powershell -Command "Write-Output 'Hello World'"`,
+			exec: func(t *testing.T, cmd string) {
+				proc := NewProc(cmd)
+				if err := proc.Start().Err(); err != nil {
+					t.Fatal(err)
+				}
+				if err := proc.Wait().Err(); err != nil {
+					t.Fatal(err)
+				}
+
+				if strings.TrimSpace(proc.Result()) != "Hello World" {
+					t.Errorf("unexpected result: %s", proc.Result())
+				}
+			},
+		},
+		{
+			name:   "access proc.Out()",
+			cmdStr: `powershell -Command "Write-Output 'Hello World'"`,
+			exec: func(t *testing.T, cmd string) {
+				proc := NewProc(cmd)
+				if err := proc.Start().Wait().Err(); err != nil {
+					t.Fatal(err)
+				}
+
+				buf := new(bytes.Buffer)
+				if _, err := buf.ReadFrom(proc.Out()); err != nil {
+					t.Fatal(err)
+				}
+
+				if strings.TrimSpace(buf.String()) != "Hello World" {
+					t.Errorf("unexpected result: %s", buf.String())
+				}
+			},
+		},
+		{
+			name:   "with expansion",
+			cmdStr: `powershell -Command "Write-Output '$MSG'"`,
+			exec: func(t *testing.T, cmd string) {
+				proc := NewProcWithVars(cmd, vars.New().SetVar("MSG", "Hello World"))
+				if err := proc.Start().Err(); err != nil {
+					t.Fatal(err)
+				}
+				if err := proc.Wait().Err(); err != nil {
+					t.Fatal(err)
+				}
+				if strings.TrimSpace(proc.Result()) != "Hello World" {
+					t.Errorf("unexpected result: %s", proc.Result())
+				}
+			},
+		},
+		{
+			name:   "custom stdout/stderr",
+			cmdStr: `powershell -Command "Write-Output 'Hello World'"`,
+			exec: func(t *testing.T, cmd string) {
+				proc := NewProc(cmd)
+				buf := new(bytes.Buffer)
+				proc.SetStdout(buf)
+				proc.SetStderr(buf)
+
+				if err := proc.Start().Wait().Err(); err != nil {
+					t.Fatalf("Failed to start/wait for proc: %s", err)
+				}
+
+				if strings.TrimSpace(buf.String()) != "Hello World" {
+					t.Errorf("unexpected result: %s", buf.String())
+				}
+			},
+		},
+		{
+			name:   "start with error",
+			cmdStr: `foo "Hello World"`,
+			exec: func(t *testing.T, cmd string) {
+				proc := NewProc(cmd)
+				if err := proc.Start().Err(); err == nil {
+					t.Fatalf("Expecting error, but got none")
+				}
+
+				if err := proc.Wait().Err(); err == nil {
+					t.Fatal("Expecting error, but got none")
+				}
+
+				if strings.TrimSpace(proc.Result()) == "Hello World" {
+					t.Errorf("Expecting error but did not get it")
+				}
+			},
+		},
+		{
+			name:   "run with result",
+			cmdStr: `powershell -Command "Write-Output 'Hello World'"`,
+			exec: func(t *testing.T, cmd string) {
+				proc := NewProc(cmd)
+				if err := proc.Run().Err(); err != nil {
+					t.Fatal(err)
+				}
+				if strings.TrimSpace(proc.Result()) != "Hello World" {
+					t.Errorf("unexpected result: %s", proc.Result())
+				}
+			},
+		},
+		{
+			name:   "run with proc.Out()",
+			cmdStr: `powershell -Command "Write-Output 'Hello World'"`,
+			exec: func(t *testing.T, cmd string) {
+				proc := NewProc(cmd)
+				if err := proc.Run().Err(); err != nil {
+					t.Fatal(err)
+				}
+				buf := new(bytes.Buffer)
+				if _, err := buf.ReadFrom(proc.Out()); err != nil {
+					t.Fatal(err)
+				}
+
+				if strings.TrimSpace(buf.String()) != "Hello World" {
+					t.Errorf("unexpected result: %s", buf.String())
+				}
+			},
+		},
+		{
+			name:   "missing command with Result",
+			cmdStr: `foobar "Hello World"`,
+			exec: func(t *testing.T, cmd string) {
+				proc := NewProc(cmd)
+
+				if err := proc.Run().Err(); err == nil {
+					t.Fatalf("Expecting error, but got none")
+				}
+				result := proc.Result()
+				if strings.TrimSpace(result) == "Hello World" {
+					t.Errorf("Expecting error but did not get it")
+				}
+				if !strings.Contains(result, "not recognized") && !strings.Contains(result, "not found") {
+					t.Errorf("Expecting result with error message, got: %s", result)
+				}
+			},
+		},
+		{
+			name:   "missing command with proc.Out",
+			cmdStr: `foobar "Hello World"`,
+			exec: func(t *testing.T, cmd string) {
+				proc := NewProc(cmd)
+
+				if err := proc.Run().Err(); err == nil {
+					t.Fatalf("Expecting error, but got none")
+				}
+				result := proc.Result()
+				if !strings.Contains(result, "not recognized") && !strings.Contains(result, "not found") {
+					t.Errorf("Expecting result with error message, got: %s", result)
+				}
+			},
+		},
+		{
+			name:   "bad command with result",
+			cmdStr: `powershell -Command "Get-Date -InvalidParameter"`,
+			exec: func(t *testing.T, cmd string) {
+				proc := NewProc(cmd)
+
+				err := proc.Run().Err()
+				if err == nil {
+					t.Fatalf("Expecting error, but got none")
+				}
+
+				result := strings.TrimSpace(proc.Result())
+				if !strings.Contains(strings.ToLower(result), "parameter") {
+					t.Errorf("Expecting error but did not get it")
+				}
+			},
+		},
+		{
+			name:   "bad command with proc.Out",
+			cmdStr: `powershell -Command "Get-Date -InvalidParameter"`,
+			exec: func(t *testing.T, cmd string) {
+				proc := NewProc(cmd)
+
+				err := proc.Run().Err()
+				if err == nil {
+					t.Fatalf("Expecting error, but got none")
+				}
+
+				buf := new(bytes.Buffer)
+				if _, err := buf.ReadFrom(proc.Out()); err != nil {
+					t.Fatal(err)
+				}
+
+				result := strings.TrimSpace(buf.String())
+				if !strings.Contains(strings.ToLower(result), "parameter") {
+					t.Errorf("Expecting error message, but got: %s", result)
+				}
+			},
+		},
+		{
+			name:   "proc status",
+			cmdStr: `powershell -Command "Write-Output 'HELLO WORLD!'"`,
+			exec: func(t *testing.T, cmd string) {
+				p := NewProc(cmd).Start()
+
+				if p.Err() != nil {
+					t.Fatal("Unexpected error:", p.Err().Error())
+				}
+				if p.ExitCode() != -1 {
+					t.Fatal("Expecting -1, got:", p.ExitCode())
+				}
+				if p.IsSuccess() {
+					t.Fatal("Success should be false")
+				}
+				if !p.hasStarted() {
+					t.Fatal("proc has not started")
+				}
+
+				// wait for proc to finish
+				if err := p.Wait().Err(); err != nil {
+					t.Fatalf("failed to wait for proc to finish: %s", err)
+				}
+
+				if p.Result() != "HELLO WORLD!" {
+					t.Errorf("Unexpected proc.Result(): %s", p.Result())
+				}
+
+				if p.ExitCode() != 0 {
+					t.Fatal("Expecting exit code 0, got:", p.ExitCode())
+				}
+				if !p.IsSuccess() {
+					t.Fatal("Process should be success")
+				}
+			},
+		},
+		{
+			name:   "with working dir",
+			cmdStr: `powershell -Command "New-Item -Path 'testfile.txt' -ItemType 'file' -Force"`,
+			exec: func(t *testing.T, cmd string) {
+				dir, err := os.MkdirTemp("", "TESTDIR")
+				if err != nil {
+					t.Fatalf("Failed to create temp dir: %s", err)
+				}
+				defer os.RemoveAll(dir)
+
+				p := NewProc(cmd).SetWorkDir(dir)
+				if p.cmd.Dir != dir {
+					t.Fatalf("Not setting working dir")
+				}
+
+				run := p.Run()
+				if err := run.Err(); err != nil {
+					t.Fatalf("failed to run: %s", err)
+				}
+				if _, err := os.Stat(filepath.Join(dir, "testfile.txt")); err != nil {
+					t.Fatalf("Unexpected error looking for file: %s", err)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.exec(t, test.cmdStr)
+		})
+	}
+}
+
+func TestStartProc(t *testing.T) {
+	tests := []struct {
+		name   string
+		cmdStr string
+		exec   func(*testing.T, string)
+	}{
+		{
+			name:   "access result",
+			cmdStr: `powershell -Command "Write-Output 'Hello World'"`,
+			exec: func(t *testing.T, cmd string) {
+				proc := StartProc(cmd).Wait()
+				if err := proc.Err(); err != nil {
+					t.Fatalf("failed to start/wait proc: %s", err)
+				}
+				if strings.TrimSpace(proc.Result()) != "Hello World" {
+					t.Errorf("unexpected result: %s", proc.Result())
+				}
+			},
+		},
+		{
+			name:   "access proc.Out",
+			cmdStr: `powershell -Command "Write-Output 'Hello World'"`,
+			exec: func(t *testing.T, cmd string) {
+				proc := StartProc(cmd)
+
+				if err := proc.Wait().Err(); err != nil {
+					t.Fatalf("failed to wait: %s", err)
+				}
+
+				buf := new(bytes.Buffer)
+
+				if _, err := buf.ReadFrom(proc.Out()); err != nil {
+					t.Error(err)
+				}
+				if strings.TrimSpace(buf.String()) != "Hello World" {
+					t.Errorf("unexpected result: %s", buf.String())
+				}
+			},
+		},
+		{
+			name:   "with expansion",
+			cmdStr: `powershell -Command "Write-Output '$MSG'"`,
+			exec: func(t *testing.T, cmd string) {
+				proc := StartProcWithVars(cmd, vars.New().SetVar("MSG", "Hello World")).Wait()
+				if err := proc.Err(); err != nil {
+					t.Fatal(err)
+				}
+				if strings.TrimSpace(proc.Result()) != "Hello World" {
+					t.Errorf("unexpected result: %s", proc.Result())
+				}
+			},
+		},
+		{
+			name:   "test proc status",
+			cmdStr: `powershell -Command "Write-Output 'HELLO WORLD!'"`,
+			exec: func(t *testing.T, cmd string) {
+				p := StartProc(cmd)
+				if p.Err() != nil {
+					t.Fatal("Unexpected error:", p.Err().Error())
+				}
+				if p.ExitCode() != -1 {
+					t.Fatal("Expecting -1, got:", p.ExitCode())
+				}
+				if p.IsSuccess() {
+					t.Fatal("Success should be false")
+				}
+				if !p.hasStarted() {
+					t.Fatal("proc has not started")
+				}
+
+				// wait for proc to finish
+				if err := p.Wait().Err(); err != nil {
+					t.Fatalf("failed to wait for proc to finish: %s", err)
+				}
+
+				if p.Result() != "HELLO WORLD!" {
+					t.Errorf("Unexpected proc.Result(): %s", p.Result())
+				}
+
+				if p.ExitCode() != 0 {
+					t.Fatal("Expecting exit code 0, got:", p.ExitCode())
+				}
+				if !p.IsSuccess() {
+					t.Fatal("Process should be success")
+				}
+			},
+		},
+		{
+			name:   "long-running",
+			cmdStr: `powershell -Command "for($i=1; $i -le 3; $i++) { Write-Output 'HELLO WORLD!'; Start-Sleep -m 700 }"`,
+			exec: func(t *testing.T, cmd string) {
+				p := StartProc(cmd).Wait()
+
+				if p.Err() != nil {
+					t.Fatal(p.Err())
+				}
+
+				data := &bytes.Buffer{}
+				if _, err := data.ReadFrom(p.Out()); err != nil {
+					t.Fatal(err)
+				}
+
+				result := strings.TrimSpace(data.String())
+				lines := strings.Split(result, "\n")
+				if len(lines) != 3 {
+					t.Fatal("unexpected lines generated:", len(lines))
+				}
+				if !strings.Contains(result, "HELLO WORLD!") {
+					t.Fatal("Unexpected result:", result)
+				}
+			},
+		},
+		{
+			name:   "missing command with result",
+			cmdStr: `foobar "HELLO WORLD!"`,
+			exec: func(t *testing.T, cmd string) {
+				proc := StartProc(cmd).Wait()
+				if proc.Err() == nil {
+					t.Error("expecting command to fail")
+				}
+				result := proc.Result()
+				if !strings.Contains(result, "not recognized") && !strings.Contains(result, "not found") {
+					t.Errorf("Expecting result with error message, got: %s", result)
+				}
+			},
+		},
+		{
+			name:   "missing command with proc.Out",
+			cmdStr: `foobar "HELLO WORLD!"`,
+			exec: func(t *testing.T, cmd string) {
+				proc := StartProc(cmd).Wait()
+				if proc.Err() == nil {
+					t.Error("expecting command to fail")
+				}
+				buf := new(bytes.Buffer)
+				if _, err := buf.ReadFrom(proc.Out()); err != nil {
+					t.Fatal(err)
+				}
+				if buf.Len() != 0 {
+					t.Error("Unexpected output from stdout/stderr")
+				}
+			},
+		},
+		{
+			name:   "bad command",
+			cmdStr: `powershell -Command "Get-Date -InvalidParameter"`,
+			exec: func(t *testing.T, cmd string) {
+				proc := StartProc(cmd).Wait()
+				if proc.Err() == nil {
+					t.Error("expecting command to fail")
+				}
+				result := proc.Result()
+				if !strings.Contains(strings.ToLower(result), "parameter") {
+					t.Errorf("Expecting error message, got: %s", result)
+				}
+			},
+		},
+		{
+			name:   "bad command with proc.Out",
+			cmdStr: `powershell -Command "Get-Date -InvalidParameter"`,
+			exec: func(t *testing.T, cmd string) {
+				proc := StartProc(cmd).Wait()
+				if proc.Err() == nil {
+					t.Error("expecting command to fail")
+				}
+
+				buf := new(bytes.Buffer)
+				if _, err := buf.ReadFrom(proc.Out()); err != nil {
+					t.Fatal(err)
+				}
+
+				result := strings.TrimSpace(buf.String())
+				if !strings.Contains(strings.ToLower(result), "parameter") {
+					t.Errorf("Expecting error message, got: %s", result)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.exec(t, test.cmdStr)
+		})
+	}
+}
+
+func TestRunProc(t *testing.T) {
+	tests := []struct {
+		name   string
+		cmdStr string
+		exec   func(*testing.T, string)
+	}{
+		{
+			name:   "access result",
+			cmdStr: `powershell -Command "Write-Output 'HELLO WORLD!'"`,
+			exec: func(t *testing.T, cmd string) {
+				p := RunProc(cmd)
+				if p.ExitCode() != 0 {
+					t.Fatal("Expecting exit code 0, got:", p.ExitCode())
+				}
+				if !p.IsSuccess() {
+					t.Fatal("Process should be success")
+				}
+				if p.Result() != "HELLO WORLD!" {
+					t.Fatal("Unexpected command result:", p.Result())
+				}
+			},
+		},
+		{
+			name:   "access proc.Out()",
+			cmdStr: `powershell -Command "Write-Output 'HELLO WORLD!'"`,
+			exec: func(t *testing.T, cmd string) {
+				p := RunProc(cmd)
+				if p.ExitCode() != 0 {
+					t.Fatal("Expecting exit code 0, got:", p.ExitCode())
+				}
+				if !p.IsSuccess() {
+					t.Fatal("Process should be success")
+				}
+				result := new(bytes.Buffer)
+				if _, err := result.ReadFrom(p.Out()); err != nil {
+					t.Fatal(err)
+				}
+
+				if strings.TrimSpace(result.String()) != "HELLO WORLD!" {
+					t.Fatal("Unexpected command result:", result.String())
+				}
+			},
+		},
+		{
+			name:   "with expansion",
+			cmdStr: `powershell -Command "Write-Output '$MSG'"`,
+			exec: func(t *testing.T, cmd string) {
+				v := vars.New().Vars("MSG='Hello World'")
+				proc := RunProcWithVars(cmd, v)
+				if err := proc.Err(); err != nil {
+					t.Fatalf("failed to run proc: %s", err)
+				}
+				if proc.Result() != v.Val("MSG") {
+					t.Fatal("Unexpected command result:", proc.Result())
+				}
+			},
+		},
+		{
+			name:   "missing command with result",
+			cmdStr: `foobar "HELLO WORLD!"`,
+			exec: func(t *testing.T, cmd string) {
+				proc := RunProc(cmd)
+				if proc.Err() == nil {
+					t.Error("expecting command to fail")
+				}
+				result := proc.Result()
+				if !strings.Contains(result, "not recognized") && !strings.Contains(result, "not found") {
+					t.Errorf("Expecting result with error message, got: %s", result)
+				}
+			},
+		},
+		{
+			name:   "missing command with proc.Out",
+			cmdStr: `foobar "HELLO WORLD!"`,
+			exec: func(t *testing.T, cmd string) {
+				proc := RunProc(cmd)
+				if proc.Err() == nil {
+					t.Error("expecting command to fail")
+				}
+
+				buf := new(bytes.Buffer)
+				if _, err := buf.ReadFrom(proc.Out()); err != nil {
+					t.Fatal(err)
+				}
+
+				result := buf.String()
+				if result != "" {
+					t.Errorf("Expecting no output, but got %s", result)
+				}
+			},
+		},
+		{
+			name:   "bad command with result",
+			cmdStr: `powershell -Command "Get-Date -InvalidParameter"`,
+			exec: func(t *testing.T, cmd string) {
+				proc := RunProc(cmd)
+				if proc.Err() == nil {
+					t.Error("expecting command to fail")
+				}
+				result := proc.Result()
+				if !strings.Contains(strings.ToLower(result), "parameter") {
+					t.Errorf("Expecting error message, got: %s", result)
+				}
+			},
+		},
+		{
+			name:   "bad command option with proc.Out",
+			cmdStr: `powershell -Command "Get-Date -InvalidParameter"`,
+			exec: func(t *testing.T, cmd string) {
+				proc := RunProc(cmd)
+				if proc.Err() == nil {
+					t.Error("expecting command to fail")
+				}
+
+				buf := new(bytes.Buffer)
+				if _, err := buf.ReadFrom(proc.Out()); err != nil {
+					t.Fatal(err)
+				}
+
+				result := buf.String()
+				if !strings.Contains(strings.ToLower(result), "parameter") {
+					t.Errorf("Expecting error message, got: %s", result)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.exec(t, test.cmdStr)
+		})
+	}
+}
+
+func TestRun(t *testing.T) {
+	tests := []struct {
+		name   string
+		cmdStr string
+		exec   func(string)
+	}{
+		{
+			name:   "simple run",
+			cmdStr: `powershell -Command "Write-Output 'HELLO WORLD!'"`,
+			exec: func(cmd string) {
+				result := Run(cmd)
+				if result != "HELLO WORLD!" {
+					t.Fatal("Unexpected command result:", result)
+				}
+			},
+		},
+		{
+			name:   "run with expansion",
+			cmdStr: `powershell -Command "Write-Output '$MSG'"`,
+			exec: func(cmd string) {
+				result := RunWithVars(cmd, vars.New().SetVar("MSG", "Hello World"))
+				if result != "Hello World" {
+					t.Fatal("Unexpected command result:", result)
+				}
+			},
+		},
+		{
+			name:   "missing command",
+			cmdStr: `foobar "HELLO WORLD!"`,
+			exec: func(cmd string) {
+				result := Run(cmd)
+				if !strings.Contains(result, "not recognized") && !strings.Contains(result, "not found") {
+					t.Errorf("Expecting result with error message, got: %s", result)
+				}
+			},
+		},
+		{
+			name:   "bad command",
+			cmdStr: `powershell -Command "Get-Command -InvalidParameter"`,
+			exec: func(cmd string) {
+				result := Run(cmd)
+				if !strings.Contains(strings.ToLower(result), "parameter") {
+					t.Errorf("Expecting error message, got: %s", result)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.exec(test.cmdStr)
+		})
+	}
+}

--- a/filesys_test.go
+++ b/filesys_test.go
@@ -2,11 +2,12 @@ package gexe
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
 func TestFileReadWrite(t *testing.T) {
-	path := "/tmp/test_writer_reader.txt"
+	path := filepath.Join(t.TempDir(), "test_writer_reader.txt")
 	content := "Hello from file"
 	defer os.RemoveAll(path)
 

--- a/fs/file_reader_test.go
+++ b/fs/file_reader_test.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"bytes"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -19,7 +20,7 @@ func TestFileReader(t *testing.T) {
 	}{
 		{
 			name: "read.string",
-			file: testFile{path: "/tmp/echo_test_read_string.txt", content: "Hello from gexe"},
+			file: testFile{path: filepath.Join(t.TempDir(), "echo_test_read_string.txt"), content: "Hello from gexe"},
 			test: func(t *testing.T, file testFile) {
 				fr := Read(file.path)
 				if fr.Err() != nil {
@@ -33,7 +34,7 @@ func TestFileReader(t *testing.T) {
 		},
 		{
 			name: "read.lines",
-			file: testFile{path: "/tmp/echo_test_read_lines.txt", content: "Hello from\ngexe\ngexe\ngexe"},
+			file: testFile{path: filepath.Join(t.TempDir(), "echo_test_read_lines.txt"), content: "Hello from\ngexe\ngexe\ngexe"},
 			test: func(t *testing.T, file testFile) {
 				fr := Read(file.path)
 				if fr.Err() != nil {
@@ -54,7 +55,7 @@ func TestFileReader(t *testing.T) {
 		},
 		{
 			name: "read.bytes",
-			file: testFile{path: "/tmp/echo_test_read_bytes.txt", content: "Hello from gexe"},
+			file: testFile{path: filepath.Join(t.TempDir(), "echo_test_read_bytes.txt"), content: "Hello from gexe"},
 			test: func(t *testing.T, file testFile) {
 				fr := Read(file.path)
 				if fr.Err() != nil {
@@ -68,7 +69,7 @@ func TestFileReader(t *testing.T) {
 		},
 		{
 			name: "read.writeTo",
-			file: testFile{path: "/tmp/echo_test_read_writeTo.txt", content: "Hello from gexe"},
+			file: testFile{path: filepath.Join(t.TempDir(), "echo_test_read_writeTo.txt"), content: "Hello from gexe"},
 			test: func(t *testing.T, file testFile) {
 				buf := new(bytes.Buffer)
 				fr := Read(file.path).Into(buf)

--- a/fs/file_writer_test.go
+++ b/fs/file_writer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -20,7 +21,7 @@ func TestFileWriter(t *testing.T) {
 		{
 			name: "write.string",
 			write: func(t *testing.T) testFile {
-				file := testFile{path: "/tmp/echo_test_write_string.txt", content: "Hello Write File"}
+				file := testFile{path: filepath.Join(t.TempDir(), "echo_test_write_string.txt"), content: "Hello Write File"}
 				f := Write(file.path).String(file.content)
 				if f.Err() != nil {
 					t.Fatal(f.Err())
@@ -37,7 +38,7 @@ func TestFileWriter(t *testing.T) {
 		{
 			name: "write.lines",
 			write: func(t *testing.T) testFile {
-				file := testFile{path: "/tmp/echo_test_write_lines.txt", content: ""}
+				file := testFile{path: filepath.Join(t.TempDir(), "echo_test_write_lines.txt"), content: ""}
 				f := Write(file.path).Lines([]string{"Hello", "gexe", "gexe"})
 				if f.Err() != nil {
 					t.Fatal(f.Err())
@@ -55,7 +56,7 @@ func TestFileWriter(t *testing.T) {
 		{
 			name: "write.bytes",
 			write: func(t *testing.T) testFile {
-				file := testFile{path: "/tmp/echo_test_write_bytes.txt", content: "Hello Write File"}
+				file := testFile{path: filepath.Join(t.TempDir(), "echo_test_write_bytes.txt"), content: "Hello Write File"}
 				f := Write(file.path).Bytes([]byte(file.content))
 				if f.Err() != nil {
 					t.Fatal(f.Err())
@@ -72,7 +73,7 @@ func TestFileWriter(t *testing.T) {
 		{
 			name: "write.readFrom",
 			write: func(t *testing.T) testFile {
-				file := testFile{path: "/tmp/echo_test_write_bytes.txt", content: "hello from buffer"}
+				file := testFile{path: filepath.Join(t.TempDir(), "echo_test_write_bytes.txt"), content: "hello from buffer"}
 				buf := bytes.NewBufferString(file.content)
 				f := Write(file.path).From(buf)
 				if f.Err() != nil {
@@ -90,7 +91,7 @@ func TestFileWriter(t *testing.T) {
 		{
 			name: "write.truncate",
 			write: func(t *testing.T) testFile {
-				file := testFile{path: "/tmp/echo_test_write_truncate.txt", content: "Hello Write File"}
+				file := testFile{path: filepath.Join(t.TempDir(), "echo_test_write_truncate.txt"), content: "Hello Write File"}
 				f := Write(file.path).String("I will be truncated").String(file.content)
 				if f.Err() != nil {
 					t.Fatal(f.Err())
@@ -130,7 +131,7 @@ func TestFileAppender(t *testing.T) {
 		{
 			name: "append.string",
 			write: func(t *testing.T) testFile {
-				file := testFile{path: "/tmp/echo_test_write_string.txt", content: "how are you?"}
+				file := testFile{path: filepath.Join(t.TempDir(), "echo_test_write_string.txt"), content: "how are you?"}
 				f := Write(file.path).String("Hello, ")
 				if f.Err() != nil {
 					t.Fatal(f.Err())
@@ -148,7 +149,7 @@ func TestFileAppender(t *testing.T) {
 		{
 			name: "append.lines",
 			write: func(t *testing.T) testFile {
-				file := testFile{path: "/tmp/echo_test_write_lines.txt", content: ""}
+				file := testFile{path: filepath.Join(t.TempDir(), "echo_test_write_lines.txt"), content: ""}
 				f := Write(file.path).String("Alo\n")
 				if f.Err() != nil {
 					t.Fatal(f.Err())
@@ -167,7 +168,7 @@ func TestFileAppender(t *testing.T) {
 		{
 			name: "append.readFrom",
 			write: func(t *testing.T) testFile {
-				file := testFile{path: "/tmp/echo_test_write_bytes.txt", content: "hello from buffer"}
+				file := testFile{path: filepath.Join(t.TempDir(), "echo_test_write_bytes.txt"), content: "hello from buffer"}
 				buf := bytes.NewBufferString(file.content)
 				f := Write(file.path).String("Hi! ")
 				if f.Err() != nil {

--- a/fs/fspath_test.go
+++ b/fs/fspath_test.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -30,7 +31,7 @@ func TestPathMethods(t *testing.T) {
 		},
 		{
 			name: "path exist",
-			path: "/tmp/myfile.txt",
+			path: filepath.Join(t.TempDir(), "myfile.txt"),
 			test: func(t *testing.T, path string) {
 				if err := Write(path).String("hello").Err(); err != nil {
 					t.Fatalf("unable to write test file: %s", err)
@@ -46,7 +47,7 @@ func TestPathMethods(t *testing.T) {
 		},
 		{
 			name: "make dir",
-			path: "/tmp/mydir",
+			path: filepath.Join(t.TempDir(), "mydir"),
 			test: func(t *testing.T, path string) {
 				p := Path(path).MkDir(0644)
 				if p.Err() != nil {
@@ -61,7 +62,7 @@ func TestPathMethods(t *testing.T) {
 		},
 		{
 			name: "remove file",
-			path: "/tmp/myfile.txt",
+			path: filepath.Join(t.TempDir(), "myfile.txt"),
 			test: func(t *testing.T, path string) {
 				if err := Write(path).String("hello").Err(); err != nil {
 					t.Fatalf("unable to write test file: %s", err)
@@ -80,7 +81,7 @@ func TestPathMethods(t *testing.T) {
 		},
 		{
 			name: "count dir",
-			path: "/tmp/mydir",
+			path: filepath.Join(t.TempDir(), "mydir"),
 			test: func(t *testing.T, path string) {
 				if err := os.Mkdir(path, 0766); err != nil {
 					t.Fatalf("failed to create dir for test: %s", err)

--- a/procs_windows_test.go
+++ b/procs_windows_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build windows
 
 package gexe
 
@@ -15,7 +15,7 @@ func TestEchoRun(t *testing.T) {
 	}{
 		{
 			name:   "start proc",
-			cmdStr: `echo "HELLO WORLD!"`,
+			cmdStr: `powershell.exe -Command "Write-Output 'HELLO WORLD!'"`,
 			exec: func(t *testing.T, cmd string) {
 				p := DefaultEcho.StartProc(cmd)
 				if p.Err() != nil {
@@ -48,7 +48,7 @@ func TestEchoRun(t *testing.T) {
 		},
 		{
 			name:   "start proc/long-running",
-			cmdStr: `/bin/sh -c "for i in {1..3}; do echo 'HELLO WORLD!\$i'; sleep 0.2; done"`,
+			cmdStr: `powershell.exe -Command "Write-Host 'HELLO WORLD!'; Start-Sleep -Milliseconds 600"`,
 			exec: func(t *testing.T, cmd string) {
 				p := DefaultEcho.StartProc(cmd)
 				if p.Err() != nil {
@@ -66,7 +66,7 @@ func TestEchoRun(t *testing.T) {
 		},
 		{
 			name:   "run proc",
-			cmdStr: `echo "HELLO WORLD!"`,
+			cmdStr: `powershell.exe -Command "Write-Output 'HELLO WORLD!'"`,
 			exec: func(t *testing.T, cmd string) {
 				p := DefaultEcho.RunProc(cmd)
 				if p.ExitCode() != 0 {
@@ -82,7 +82,7 @@ func TestEchoRun(t *testing.T) {
 		},
 		{
 			name:   "simple run",
-			cmdStr: `echo "HELLO WORLD!"`,
+			cmdStr: `powershell.exe -Command "Write-Output 'HELLO WORLD!'"`,
 			exec: func(t *testing.T, cmd string) {
 				result := DefaultEcho.Run(cmd)
 				if result != "HELLO WORLD!" {
@@ -93,7 +93,7 @@ func TestEchoRun(t *testing.T) {
 
 		{
 			name:   "simple with expansion",
-			cmdStr: "echo $MSG",
+			cmdStr: `powershell.exe -Command "Write-Output '$MSG'"`,
 			exec: func(t *testing.T, cmd string) {
 				DefaultEcho.Variables().Vars("MSG=Hello World")
 				result := DefaultEcho.Run(cmd)


### PR DESCRIPTION
This patch adds gexe support for windows:

* Removes exec command attributes not directly supported in Windows
* Update all tests to use Windows-specific commands
* Update `CommandBuilder` type to execute Windows command
* Update `CommandBuilder.Pipe` with Windows-specific implementation
* Add tests for `CommandBuilder` for Windows
* Update GitHub/Actions to run on Windows

Fixes #27 
Fixes #65 