### PR TITLE
Replace gexe.Echo with gexe.Session type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/vladimirvivien/gexe.svg)](https://pkg.go.dev/github.com/vladimirvivien/gexe)
-[![Go Report Card](https://goreportcard.com/badge/github.com/vladimirvivien/echo)](https://goreportcard.com/report/github.com/vladimirvivien/echo)
+[![Go Report Card](https://goreportcard.com/badge/github.com/vladimirvivien/gexe)](https://goreportcard.com/report/github.com/vladimirvivien/gexe)
 ![Build](https://github.com/vladimirvivien/gexe/actions/workflows/build.yml/badge.svg)
 # Project `gexe`
 Package with script-like API for system operation and automation!
 
 The goal of project `gexe` is to make it simple to write code for system operation and task automation using a script-like API that offers the security and the type safety of the Go programming language (see [/examples](/examples/)).
-
-> NOTE: this project got renamed from Echo to Gexe (see Project Name Change)
 
 ## What can you do with `gexe`?
 * Parse and execute OS plain text commands, as you would in a shell.
@@ -63,7 +61,7 @@ func main() {
 				fmt.Printf("Build for %s/%s failed: %s\n", arch, opsys, result)
 				os.Exit(1)
 			}
-			fmt.Printf("Build %s/%s: %s OK\n", arch, opsys, echo.Eval("$binpath"))
+			fmt.Printf("Build %s/%s: %s OK\n", arch, opsys, gexe.Eval("$binpath"))
 		}
 	}
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,51 +1,54 @@
-# `gexe` 
-The goal of project `gexe` is to make it simple to write code for system operation and task automation using a script-like API that offers the security and the type safety of the Go programming language.
+# gexe
 
-## The `gexe` session
+The goal of project `gexe` is to make it simple to write code for system operations and task automation using a script-like API that offers the security and type safety of the Go programming language.
+
+## The gexe session
 To get access to `gexe`'s functionalities, you must create a session. This is done as follows:
 
 ```go
 g := gexe.New()
 ```
-Variable `g` starts a `gexe` session (called Echo) that provide access to the followings:
-* Access functionalities from `gexe` subpackages
-* A session variable map
+
+Variable `g` starts a `gexe` session (type `gexe.Session`) that provides access to the following:
+* Access to all of `gexe` functionalities
+* Session variables
 * Reported errors
 
-A `gexe` session provides types and functions that offer convenient access to other top-level package functionalities. For instance, we can use the previously created session to run an OS command:
+For instance, we can use the previously created session to run an OS command:
 
 ```go
 g := gexe.New()
 fmt.Println(g.Run(`echo "Hello World!"`))
 ```
 
-The top-level `gexe` package offers another level of convenience by exposing a default session called `gexe.DefaultEcho` that is created when the `gexe` package is initiated. So the previous program can be rewritten as:
+The top-level `gexe` package offers another level of convenience by exposing a default session called `gexe.DefaultSession` that is created when the `gexe` package is initialized. So the previous program can be rewritten as:
 
 ```go
 fmt.Println(gexe.Run(`echo "Hello World!"`))
 ```
 
-As mentioned earlier, the `gexe` session provides shortcut access to all functionalities implemented by other packages. The following shows a short snippet of the functions that you can access using a `gexe` session:
+As mentioned earlier, the `gexe` session provides shortcut access to all functionalities implemented by its subpackages. The following shows a short snippet of the functions that you can access using a `gexe` session:
 
 ```go
 gexe.Run(`echo "Hello World!"`)
 gexe.Pipe(`echo "Hello World!"`, "wc -l")
 gexe.PathExists("/tmp/myfile")
 gexe.Mkdir("/tmp/myapp")
-gexe.FileWrite("/tmp/myapp/myfile").String(gexe.Run(`echo "Hello World!"`))
+gexe.FileWrite("/tmp/myapp/myfile.txt").String(gexe.Run(`echo "Hello World!"`))
 gexe.Get("https://somehost/someresource").String()
-...
-Etc
+// ... etc
 ```
-See all top-level functions in [functions.go](../functions.go)
+See all top-level functions in [functions.go](../functions.go).
 
-These functions make use of the functionalities that are implemneted in the packages outlined below.
+These functions make use of the functionalities that are implemented in the packages outlined below.
 
-## Package `exec`
-Package `exec` can be used to launch and manage external processes by wraping the `os/exec` types.  The package exposes functionalities such as the folliwngs:
-* Lauhch / kill externaal processes
+---
+
+## Package exec
+Package `exec` can be used to launch and manage external processes by wrapping the `os/exec` types. The package exposes functionalities such as:
+* External processes control (launch, kill, etc)
 * Retrieve process information
-* Launch and manage multiple processes
+* Launch and manage multiple processes (serially or concurrently)
 
 Package `exec` exposes type `Proc` which provides an entry point for process management. The following example shows how the package works:
 
@@ -53,7 +56,7 @@ Package `exec` exposes type `Proc` which provides an entry point for process man
 p := exec.NewProc(`echo "Hello World!"`)
 p.Start()
 if p.IsSuccess() {
-    fmt.Println("processess launched okay")
+    fmt.Println("processes launched okay")
 }
 ```
 
@@ -64,11 +67,11 @@ msg := exec.Run(`echo "Hello World!"`)
 fmt.Println(msg)
 ```
 
-The `gexe` package provides functions to access `exec` types to make it easy to launch and mange processes. The previous examples can be done using the `gexe` package:
+The `gexe` package provides functions to access `exec` types to make it easy to launch and manage processes. The previous examples can be done using the `gexe` package:
 
 ```go
 gexe.SetVar("msg", "World!")
-message = gexe.Run(`echo "Hello $msg"`)
+message := gexe.Run(`echo "Hello $msg"`)
 fmt.Print(message)
 ```
 
@@ -80,7 +83,7 @@ cmds := exec.Commands(
     "wget https://text/file1",
     "wget https://text/file2",
     "wget https://text/file3",
-).WithPolicy(exec.ConcerrentExecPolicy).Run()
+).WithPolicy(exec.ConcurrentExecPolicy).Run()
 
 if len(cmds.Errs()) > 0 {
     fmt.Println("There were errors")
@@ -100,7 +103,7 @@ if len(cmds.Errs()) > 0 {
     fmt.Println("There were errors")
 }
 ```
-As before, functionalities from the `exec` package is exposed via the `gexe` package. The previous example can be achieved using the `gexe` package as follows:
+As before, functionalities from the `exec` package are exposed via the `gexe` package. The previous example can be achieved using the `gexe` package as follows:
 
 ```go
 cmds := gexe.RunConcur(
@@ -114,11 +117,14 @@ if len(cmds.Errs()) > 0 {
 }
 ```
 
-## Package `fs`
+---
+
+## Package fs
+
 This package exposes functionalities to create filesystem artifacts such as directories and files. The package makes it easy to create files and add content from different sources including string, bytes, other files, etc.
 
 ### Path and directories
-Package `fs` exposes type `Path` which provides the entry point for access an OS path. A path can point to a directory or an actual file. Once a path is referenced, the API provides additional functionalities to create or access path resources.  For instance, the following examples uses the `fs` package to create a directory:
+Package `fs` exposes type `Path` which provides the entry point for accessing an OS path. A path can point to a directory or an actual file. Once a path is referenced, the API provides additional functionalities to create or access path resources. For instance, the following example uses the `fs` package to create a directory:
 
 ```go
 dir := fs.Path("/path/to/dir").MkDir(0744)
@@ -127,7 +133,7 @@ if dir.Err() == nil {
 }
 ```
 
-Or, you can do the the same using `gexe` top-level package
+Or, you can do the same using `gexe` top-level package
 
 ```go
 dir := gexe.MkDir("/path/to/dir", 0744)
@@ -137,11 +143,11 @@ if dir.Err() == nil {
 ```
 
 ### Reading files
-The `fs` package provides access to functionalities to read content of existing files as shown in the follwoing example :
+The `fs` package provides access to functionalities to read content of existing files as shown in the following example:
 
 ```go
 data := fs.Read("/path/to/file")
-if data.Err() != nil{
+if data.Err() != nil {
     fmt.Println("Unable to read file:", data.Err())
 }
 fmt.Println("File content:", data.String())
@@ -150,14 +156,14 @@ fmt.Println("File content:", data.String())
 The previous functionality can be accessed from the `gexe` package as shown below:
 ```go
 data := gexe.ReadFile("/path/to/file")
-if data.Err() != nil{
+if data.Err() != nil {
     fmt.Println("Unable to read file:", data.Err())
 }
 fmt.Println("File content:", data.String())
 ```
 
 ### Writing files
-The `fs` package also makes it eash to write content, from different sources, to a file as shown in the example below:
+The `fs` package also makes it easy to write content, from different sources, to a file as shown in the example below:
 
 ```go
 get, _ := http.Get("https://test/file1")
@@ -171,11 +177,14 @@ get, _ := http.Get("https://test/file1")
 gexe.FileWrite("path/to/file").From(get.Body())
 ```
 
-## Package `http`
-This package uses the Gexe programming model to make it easy to programmatically interact with HTTP servers.
+---
+
+## Package http
+
+This package uses the gexe programming model to make it easy to interact with HTTP servers.
 
 ### Reading remote resources
-Reading a remote resource using the `http` package can be easily done as shown the following:
+Reading a remote resource using the `http` package can be easily done as shown in the following:
 
 ```go
 f1 := http.Get("https://test/file1").String()
@@ -184,7 +193,7 @@ fmt.Println(f1)
 Similarly, package `http` makes it easy to post data to a remote HTTP server as shown in the following example:
 
 ```go
-http.Post("https://test/message").String("Hello)
+http.Post("https://test/message").String("Hello")
 ```
 
 As before, functionalities from the `http` package are exposed as functions in the `gexe` package for easier access as shown below:
@@ -193,11 +202,16 @@ As before, functionalities from the `http` package are exposed as functions in t
 gexe.FileWrite("/tmp/eapv2.txt").String(gexe.GetUrl("https://test/file1").String())
 ```
 
-## Package `vars`
+---
+
+## Package vars
+
 Package `vars` exposes type `Variables` which lets you store named values that can be retrieved programmatically or using string expansion methods.
 
-### Type `vars.Variables`
-Type `vars.Variables` is the main type that is used to manage variables.  It exposes several methods including
+### Type vars.Variables
+
+Type `vars.Variables` is the main type that is used to manage variables. It exposes several methods including:
+
 * Set environment variables that are accessible to forked processes
 * Set session variables that are accessible to a running gexe session
 * Evaluate a string with embedded variable expansion values
@@ -207,31 +221,32 @@ The following shows how to create a variable and use it
 ```go
 v := vars.New()
 v.SetVar("msg", "World!")
-v.Eval(`Hello ${msg}!)
+v.Eval(`Hello ${msg}!`)
 ```
 
-The `gexe` session maintains an instance of type `vars.Variables` which are used to store session variable values at runtime as shown below:
+A `gexe` session maintains an instance of type `vars.Variables` which is used to store session variable values at runtime as shown below:
 
 ```go
 gexe.SetVar("msg", "World")
 gexe.Run(`echo "Hello ${msg}!"`)
 ```
-### Setting session variables 
-You can use several methods, of type `vars.Variables`, to set variables.
+### Setting session variables
 
-Setting session variables using string literals:
+You can use several methods from type `vars.Variables` to set variables.
+
+**Setting session variables using string literals:**
 
 ```go
 gexe.Vars(`MSG1="Hello"`, `MSG2=World!`)
-gexe.Run(`echo "${MSG1} $MSG2")
+gexe.Run(`echo "${MSG1} $MSG2"`)
 ```
-You can set variables using the `vars.Variables.SetVar` method:
+**You can set variables using the `vars.Variables.SetVar` method:**
 
 ```go
 gexe.SetVar("MSG1","Hello").SetVar("MSG2","World!")
 gexe.Run(`echo "${MSG1} $MSG2"`)
 ```
-Sometimes, you may want to clear a previously set variable:
+**Sometimes, you may want to clear a previously set variable:**
 
 ```go
 gexe.SetVar("MSG1","Hello").SetVar("MSG2","World!")
@@ -239,34 +254,36 @@ gexe.Run(`echo "${MSG1} $MSG2"`)
 gexe.UnsetVar("MSG1").UnsetVar("MSG2")
 ```
 ### Setting environment variables
-You can use several methods, from `vars.Variables` type, to create environment variables that can be accessed by processes launched by `gexe`.
 
-Setting environment variables using string literals:
+You can use several methods from the `vars.Variables` type to create environment variables that can be accessed by processes launched by `gexe`.
+
+**Setting environment variables using string literals:**
 
 ```go
 gexe.Envs(`GOOS="linux"`, `GOARCH=amd64`)
-gexe.Run(`go build .")
+gexe.Run(`go build .`)
 ```
 In the previous snippet, the `go build` command will have access to the environment variables `GOOS` and `GOARCH` at process runtime.
 
-Setting environment variables using key/value with method `vars.Variables.SetEnv`:
+**Setting environment variables using key/value with method `vars.Variables.SetEnv`:**
 
 ```go
 gexe.SetEnv("GOOS","linux").SetEnv("GOARCH","amd64")
-gexe.Run(`go build .")
+gexe.Run(`go build .`)
 ```
 ### Accessing variables
+
 There are a couple of ways you can access your session or environment variables once they are set.
 
-You can access your variables using variable expansion:
+**You can access your variables using variable expansion:**
 
 ```go
 gexe.SetEnv("GOOS","linux").SetEnv("GOARCH","amd64")
 gexe.Run(`echo "Building OS: $GOOS; ARC: $GOARCH"`)
 ```
-Additionally, you can use `Variables` method `Val` to access variable values directly:
+**Additionally, you can use `Variables` method `Val` to access variable values directly:**
 
 ```go
 gexe.SetEnv("GOOS","linux").SetEnv("GOARCH","amd64")
-gexe.Run(fmt.Sprintf(`echo "Building OS: %s ARC: %s`, gexe.Val("GOOS"), gexe.Val("GOARCH")))
+gexe.Run(fmt.Sprintf(`echo "Building OS: %s ARC: %s"`, gexe.Val("GOOS"), gexe.Val("GOARCH")))
 ```

--- a/echo.go
+++ b/echo.go
@@ -9,22 +9,28 @@ import (
 	"github.com/vladimirvivien/gexe/vars"
 )
 
-var (
-	// DefaultEcho surfaces an Echo session used for all package functions
-	DefaultEcho = New()
+type (
+	// Echo is a Session alias for backward compatibility
+	Echo = Session
 )
 
-// Echo represents a new Echo session used for accessing
+var (
+	// DefaultSession surfaces an gexe session used for all package functions
+	DefaultSession = New()
+	DefaultEcho    = DefaultSession // alias for backward compatibility
+)
+
+// Session represents a new session used for accessing
 // Gexe types and methods.
-type Echo struct {
+type Session struct {
 	err  error
 	vars *vars.Variables // session vars
 	prog *prog.Info
 }
 
 // New creates a new Echo session
-func New() *Echo {
-	e := &Echo{
+func New() *Session {
+	e := &Session{
 		vars: vars.New(),
 		prog: prog.Prog(),
 	}
@@ -32,13 +38,13 @@ func New() *Echo {
 }
 
 // AddExecPath adds an executable path to PATH
-func (e *Echo) AddExecPath(execPath string) {
+func (e *Session) AddExecPath(execPath string) {
 	oldPath := os.Getenv("PATH")
 	os.Setenv("PATH", fmt.Sprintf("%s%c%s", oldPath, os.PathListSeparator, e.Eval(execPath)))
 }
 
 // ProgAvail returns the full path of the program if found on exec PATH
-func (e *Echo) ProgAvail(progName string) string {
+func (e *Session) ProgAvail(progName string) string {
 	path, err := exec.LookPath(e.Eval(progName))
 	if err != nil {
 		return ""

--- a/filesys.go
+++ b/filesys.go
@@ -9,56 +9,56 @@ import (
 
 // PathExists returns true if path exists.
 // All errors causes to return false.
-func (e *Echo) PathExists(path string) bool {
+func (e *Session) PathExists(path string) bool {
 	return fs.PathWithVars(path, e.vars).Exists()
 }
 
 // MkDir creates a directory at specified path with mode value.
 // FSInfo contains information about the path or error if occured
-func (e *Echo) MkDir(path string, mode os.FileMode) *fs.FSInfo {
+func (e *Session) MkDir(path string, mode os.FileMode) *fs.FSInfo {
 	p := fs.PathWithVars(path, e.vars)
 	return p.MkDir(mode)
 }
 
 // RmPath removes specified path (dir or file).
 // Error is returned FSInfo.Err()
-func (e *Echo) RmPath(path string) *fs.FSInfo {
+func (e *Session) RmPath(path string) *fs.FSInfo {
 	p := fs.PathWithVars(path, e.vars)
 	return p.Remove()
 }
 
 // PathInfo
-func (e *Echo) PathInfo(path string) *fs.FSInfo {
+func (e *Session) PathInfo(path string) *fs.FSInfo {
 	return fs.PathWithVars(path, e.vars).Info()
 }
 
 // FileReadWithContext uses specified context to provide methods to read file
 // content at path.
-func (e *Echo) FileReadWithContext(ctx context.Context, path string) *fs.FileReader {
+func (e *Session) FileReadWithContext(ctx context.Context, path string) *fs.FileReader {
 	return fs.ReadWithContextVars(ctx, path, e.vars)
 }
 
 // FileRead provides methods to read file content
-func (e *Echo) FileRead(path string) *fs.FileReader {
+func (e *Session) FileRead(path string) *fs.FileReader {
 	return fs.ReadWithContextVars(context.Background(), path, e.vars)
 }
 
 // FileWriteWithContext uses context ctx to create a fs.FileWriter to write content to provided path
-func (e *Echo) FileWriteWithContext(ctx context.Context, path string) *fs.FileWriter {
+func (e *Session) FileWriteWithContext(ctx context.Context, path string) *fs.FileWriter {
 	return fs.WriteWithContextVars(ctx, path, e.vars)
 }
 
 // FileWrite creates a fs.FileWriter to write content to provided path
-func (e *Echo) FileWrite(path string) *fs.FileWriter {
+func (e *Session) FileWrite(path string) *fs.FileWriter {
 	return fs.WriteWithContextVars(context.Background(), path, e.vars)
 }
 
 // FileAppend creates a new fs.FileWriter to append content to provided path
-func (e *Echo) FileAppendWithContext(ctx context.Context, path string) *fs.FileWriter {
+func (e *Session) FileAppendWithContext(ctx context.Context, path string) *fs.FileWriter {
 	return fs.AppendWithContextVars(ctx, path, e.vars)
 }
 
 // FileAppend creates a new fs.FileWriter to append content to provided path
-func (e *Echo) FileAppend(path string) *fs.FileWriter {
+func (e *Session) FileAppend(path string) *fs.FileWriter {
 	return fs.AppendWithContextVars(context.Background(), path, e.vars)
 }

--- a/functions.go
+++ b/functions.go
@@ -14,7 +14,7 @@ import (
 
 // Variables returns variable map for DefaultEcho session
 func Variables() *vars.Variables {
-	return DefaultEcho.Variables()
+	return DefaultSession.Variables()
 }
 
 // Envs declares environment variables using
@@ -24,13 +24,13 @@ func Variables() *vars.Variables {
 //
 // Environment vars can be used in string values
 // using Eval("building for os=$GOOS")
-func Envs(val ...string) *Echo {
-	return DefaultEcho.Envs(val...)
+func Envs(val ...string) *Session {
+	return DefaultSession.Envs(val...)
 }
 
 // SetEnv sets a process environment variable.
-func SetEnv(name, value string) *Echo {
-	return DefaultEcho.SetEnv(name, value)
+func SetEnv(name, value string) *Session {
+	return DefaultSession.SetEnv(name, value)
 }
 
 // Vars declares multiple session-scope variables using
@@ -40,210 +40,210 @@ func SetEnv(name, value string) *Echo {
 //
 // Note that session vars are only available
 // for the running process.
-func Vars(variables ...string) *Echo {
-	return DefaultEcho.Vars(variables...)
+func Vars(variables ...string) *Session {
+	return DefaultSession.Vars(variables...)
 }
 
 // SetVar declares a session variable.
-func SetVar(name, value string) *Echo {
-	return DefaultEcho.SetVar(name, value)
+func SetVar(name, value string) *Session {
+	return DefaultSession.SetVar(name, value)
 }
 
 // Val retrieves a session or environment variable
 func Val(name string) string {
-	return DefaultEcho.Val(name)
+	return DefaultSession.Val(name)
 }
 
 // Eval returns the string str with its content expanded
 // with variable values i.e. Eval("I am $HOME") returns
 // "I am </user/home/path>"
 func Eval(str string) string {
-	return DefaultEcho.Eval(str)
+	return DefaultSession.Eval(str)
 }
 
 // NewProcWithContext setups a new process with specified context and command cmdStr and returns immediately
 // without starting. Information about the running process is stored in *exec.Proc.
 func NewProcWithContext(ctx context.Context, cmdStr string) *exec.Proc {
-	return DefaultEcho.NewProcWithContext(ctx, cmdStr)
+	return DefaultSession.NewProcWithContext(ctx, cmdStr)
 }
 
 // NewProc setups a new process with specified command cmdStr and returns immediately
 // without starting. Information about the running process is stored in *exec.Proc.
 func NewProc(cmdStr string) *exec.Proc {
-	return DefaultEcho.NewProcWithContext(context.Background(), cmdStr)
+	return DefaultSession.NewProcWithContext(context.Background(), cmdStr)
 }
 
 // StartProcWith executes the command in cmdStr with the specified contex and returns immediately
 // without waiting. Information about the running process is stored in *exec.Proc.
 func StartProcWithContext(ctx context.Context, cmdStr string) *exec.Proc {
-	return DefaultEcho.StartProcWithContext(ctx, cmdStr)
+	return DefaultSession.StartProcWithContext(ctx, cmdStr)
 }
 
 // StartProc executes the command in cmdStr and returns immediately
 // without waiting. Information about the running process is stored in *exec.Proc.
 func StartProc(cmdStr string) *exec.Proc {
-	return DefaultEcho.StartProc(cmdStr)
+	return DefaultSession.StartProc(cmdStr)
 }
 
 // RunProcWithContext executes command in cmdStr, with specified ctx, and waits for the result.
 // It returns a *Proc with information about the executed process.
 func RunProcWithContext(ctx context.Context, cmdStr string) *exec.Proc {
-	return DefaultEcho.RunProc(cmdStr)
+	return DefaultSession.RunProc(cmdStr)
 }
 
 // RunProc executes command in cmdStr and waits for the result.
 // It returns a *Proc with information about the executed process.
 func RunProc(cmdStr string) *exec.Proc {
-	return DefaultEcho.RunProc(cmdStr)
+	return DefaultSession.RunProc(cmdStr)
 }
 
 // RunWithContext executes cmdStr, with specified context, and waits for completion.
 // It returns the result as a string.
 func RunWithContext(ctx context.Context, cmdStr string) string {
-	return DefaultEcho.RunWithContext(ctx, cmdStr)
+	return DefaultSession.RunWithContext(ctx, cmdStr)
 }
 
 // Run executes cmdStr, waits, and returns the result as a string.
 func Run(cmdStr string) string {
-	return DefaultEcho.Run(cmdStr)
+	return DefaultSession.Run(cmdStr)
 }
 
 // Runout executes command cmdStr and prints out the result
 func Runout(cmdStr string) {
-	DefaultEcho.Runout(cmdStr)
+	DefaultSession.Runout(cmdStr)
 }
 
 // Commands returns a *exe.CommandBuilder to build a multi-command execution flow.
 func Commands(cmdStrs ...string) *exec.CommandBuilder {
-	return DefaultEcho.Commands(cmdStrs...)
+	return DefaultSession.Commands(cmdStrs...)
 }
 
 // StartAll starts the exection of each command sequentially and
 // does not wait for their completion.
 func StartAll(cmdStrs ...string) *exec.CommandResult {
-	return DefaultEcho.StartAll(cmdStrs...)
+	return DefaultSession.StartAll(cmdStrs...)
 }
 
 // RunAll executes each command, in cmdStrs, successively and wait for their
 // completion.
 func RunAll(cmdStrs ...string) *exec.CommandResult {
-	return DefaultEcho.RunAll(cmdStrs...)
+	return DefaultSession.RunAll(cmdStrs...)
 }
 
 // StartConcur starts the exection of each command concurrently and
 // does not wait for their completion.
 func StartConcur(cmdStrs ...string) *exec.CommandResult {
-	return DefaultEcho.StartConcur(cmdStrs...)
+	return DefaultSession.StartConcur(cmdStrs...)
 }
 
 // RunConcur executes each command, in cmdStrs, concurrently and waits
 // their completion.
 func RunConcur(cmdStrs ...string) *exec.CommandResult {
-	return DefaultEcho.RunConcur(cmdStrs...)
+	return DefaultSession.RunConcur(cmdStrs...)
 }
 
 // Pipe executes each command, in cmdStrs, by piping the result
 // of the previous command as input to the next command until done.
 func Pipe(cmdStrs ...string) *exec.PipedCommandResult {
-	return DefaultEcho.Pipe(cmdStrs...)
+	return DefaultSession.Pipe(cmdStrs...)
 }
 
 // PathExists returns true if specified path exists.
 // Any error will cause it to return false.
 func PathExists(path string) bool {
-	return DefaultEcho.PathExists(path)
+	return DefaultSession.PathExists(path)
 }
 
 // PathInfo returns information for specified path (i.e. size, etc)
 func PathInfo(path string) *fs.FSInfo {
-	return DefaultEcho.PathInfo(path)
+	return DefaultSession.PathInfo(path)
 }
 
 // MkDirs creates one or more directories along the specified path
 func MkDirs(path string, mode os.FileMode) *fs.FSInfo {
-	return DefaultEcho.MkDir(path, mode)
+	return DefaultSession.MkDir(path, mode)
 }
 
 // MkDir creates a directory with default mode 0744
 func MkDir(path string) *fs.FSInfo {
-	return DefaultEcho.MkDir(path, 0744)
+	return DefaultSession.MkDir(path, 0744)
 }
 
 // RmPath removes files or directories along specified path
 func RmPath(path string) *fs.FSInfo {
-	return DefaultEcho.RmPath(path)
+	return DefaultSession.RmPath(path)
 }
 
 // FileRead uses context ctx to read file content from path
 func FileReadWithContext(ctx context.Context, path string) *fs.FileReader {
-	return DefaultEcho.FileReadWithContext(ctx, path)
+	return DefaultSession.FileReadWithContext(ctx, path)
 }
 
 // FileRead provides methods to read file content from path
 func FileRead(path string) *fs.FileReader {
-	return DefaultEcho.FileReadWithContext(context.Background(), path)
+	return DefaultSession.FileReadWithContext(context.Background(), path)
 }
 
 // FileWriteWithContext uses context ctx to write file content to path
 func FileWriteWithContext(ctx context.Context, path string) *fs.FileWriter {
-	return DefaultEcho.FileWriteWithContext(ctx, path)
+	return DefaultSession.FileWriteWithContext(ctx, path)
 }
 
 // FileWrite provides methods to write file content to path
 func FileWrite(path string) *fs.FileWriter {
-	return DefaultEcho.FileWriteWithContext(context.Background(), path)
+	return DefaultSession.FileWriteWithContext(context.Background(), path)
 }
 
 // HttpGetWithContext uses context ctx to start an HTTP GET operation to retrieve resource at URL/path
 func HttpGetWithContext(ctx context.Context, url string, paths ...string) *http.ResourceReader {
-	return DefaultEcho.HttpGetWithContext(ctx, url, paths...)
+	return DefaultSession.HttpGetWithContext(ctx, url, paths...)
 }
 
 // HttpGet starts an HTTP GET operation to retrieve resource at URL/path
 func HttpGet(url string, paths ...string) *http.ResourceReader {
-	return DefaultEcho.HttpGetWithContext(context.Background(), url, paths...)
+	return DefaultSession.HttpGetWithContext(context.Background(), url, paths...)
 }
 
 // Get is a convenient alias for HttpGet that retrieves specified resource at given URL/path
 func Get(url string, paths ...string) *http.Response {
-	return DefaultEcho.Get(url, paths...)
+	return DefaultSession.Get(url, paths...)
 }
 
 // HttpPostWithContext uses context ctx to start an HTTP POST operation to post resource to URL/path
 func HttpPostWithContext(ctx context.Context, url string, paths ...string) *http.ResourceWriter {
-	return DefaultEcho.HttpPostWithContext(ctx, url, paths...)
+	return DefaultSession.HttpPostWithContext(ctx, url, paths...)
 }
 
 // HttpPost starts an HTTP POST operation to post resource to URL/path
 func HttpPost(url string, paths ...string) *http.ResourceWriter {
-	return DefaultEcho.HttpPostWithContext(context.Background(), url, paths...)
+	return DefaultSession.HttpPostWithContext(context.Background(), url, paths...)
 }
 
 // Post is a convenient alias for HttpPost to post data at specified URL
 func Post(data []byte, url string) *http.Response {
-	return DefaultEcho.Post(data, url)
+	return DefaultSession.Post(data, url)
 }
 
 // Prog returns program information via *prog.Info
 func Prog() *prog.Info {
-	return DefaultEcho.Prog()
+	return DefaultSession.Prog()
 }
 
 // ProgAvail returns the full path of the program if available.
 func ProgAvail(program string) string {
-	return DefaultEcho.ProgAvail(program)
+	return DefaultSession.ProgAvail(program)
 }
 
 // Workdir returns the current program's working directory
 func Workdir() string {
-	return DefaultEcho.Workdir()
+	return DefaultSession.Workdir()
 }
 
 // AddExecPath adds an executable path to PATH
 func AddExecPath(execPath string) {
-	DefaultEcho.AddExecPath(execPath)
+	DefaultSession.AddExecPath(execPath)
 }
 
 func String(s string) *str.Str {
-	return DefaultEcho.String(s)
+	return DefaultSession.String(s)
 }

--- a/http.go
+++ b/http.go
@@ -8,7 +8,7 @@ import (
 )
 
 // HttpGetWithContext uses context ctx to start an HTTP GET operation to retrieve server resource from given URL/paths.
-func (e *Echo) HttpGetWithContext(ctx context.Context, url string, paths ...string) *http.ResourceReader {
+func (e *Session) HttpGetWithContext(ctx context.Context, url string, paths ...string) *http.ResourceReader {
 	var exapandedUrl strings.Builder
 	exapandedUrl.WriteString(e.vars.Eval(url))
 	for _, path := range paths {
@@ -18,12 +18,12 @@ func (e *Echo) HttpGetWithContext(ctx context.Context, url string, paths ...stri
 }
 
 // HttpGetWithContext starts an HTTP GET operation to retrieve server resource from given URL/paths.
-func (e *Echo) HttpGet(url string, paths ...string) *http.ResourceReader {
+func (e *Session) HttpGet(url string, paths ...string) *http.ResourceReader {
 	return e.HttpGetWithContext(context.Background(), url, paths...)
 }
 
 // HttpPostWithContext uses context ctx to start an HTTP POST operation to post resource to a server at given URL/path.
-func (e *Echo) HttpPostWithContext(ctx context.Context, url string, paths ...string) *http.ResourceWriter {
+func (e *Session) HttpPostWithContext(ctx context.Context, url string, paths ...string) *http.ResourceWriter {
 	var exapandedUrl strings.Builder
 	exapandedUrl.WriteString(e.vars.Eval(url))
 	for _, path := range paths {
@@ -33,16 +33,16 @@ func (e *Echo) HttpPostWithContext(ctx context.Context, url string, paths ...str
 }
 
 // HttpPost starts an HTTP POST operation to post resource to a server at given URL/path.
-func (e *Echo) HttpPost(url string, paths ...string) *http.ResourceWriter {
+func (e *Session) HttpPost(url string, paths ...string) *http.ResourceWriter {
 	return e.HttpPostWithContext(context.Background(), url, paths...)
 }
 
 // Get is convenient alias for HttpGet to retrieve a resource at given URL/path
-func (e *Echo) Get(url string, paths ...string) *http.Response {
+func (e *Session) Get(url string, paths ...string) *http.Response {
 	return e.HttpGet(url, paths...).Do()
 }
 
 // Post is a convenient alias for HttpPost to post the specified data to given URL/path
-func (e *Echo) Post(data []byte, url string, paths ...string) *http.Response {
+func (e *Session) Post(data []byte, url string, paths ...string) *http.Response {
 	return e.HttpPost(url, paths...).Bytes(data).Do()
 }

--- a/net.go
+++ b/net.go
@@ -4,6 +4,6 @@ import (
 	"github.com/vladimirvivien/gexe/net"
 )
 
-func (e *Echo) AddressUsable(addr string) error {
+func (e *Session) AddressUsable(addr string) error {
 	return net.AddrUsable(e.Eval(addr))
 }

--- a/procs.go
+++ b/procs.go
@@ -10,126 +10,126 @@ import (
 // NewProc setups a new process with specified command cmdStr and returns immediately
 // without starting. Use Proc.Wait to wait for exection and then retrieve process result.
 // Information about the running process is stored in *exec.Proc.
-func (e *Echo) NewProcWithContext(ctx context.Context, cmdStr string) *exec.Proc {
+func (e *Session) NewProcWithContext(ctx context.Context, cmdStr string) *exec.Proc {
 	return exec.NewProcWithContextVars(ctx, cmdStr, e.vars)
 }
 
 // NewProc a convenient function that calls NewProcWithContext with a default contet.
-func (e *Echo) NewProc(cmdStr string) *exec.Proc {
+func (e *Session) NewProc(cmdStr string) *exec.Proc {
 	return exec.NewProcWithContextVars(context.Background(), cmdStr, e.vars)
 }
 
 // StartProc executes the command in cmdStr, with the specified context, and returns immediately
 // without waiting. Use Proc.Wait to wait for exection and then retrieve process result.
 // Information about the running process is stored in *Proc.
-func (e *Echo) StartProcWithContext(ctx context.Context, cmdStr string) *exec.Proc {
+func (e *Session) StartProcWithContext(ctx context.Context, cmdStr string) *exec.Proc {
 	return exec.StartProcWithContextVars(ctx, cmdStr, e.vars)
 }
 
 // StartProc executes the command in cmdStr and returns immediately
 // without waiting. Use Proc.Wait to wait for exection and then retrieve process result.
 // Information about the running process is stored in *Proc.
-func (e *Echo) StartProc(cmdStr string) *exec.Proc {
+func (e *Session) StartProc(cmdStr string) *exec.Proc {
 	return exec.StartProcWithContextVars(context.Background(), cmdStr, e.vars)
 }
 
 // RunProcWithContext executes command in cmdStr, with given context, and waits for the result.
 // It returns a *Proc with information about the executed process.
-func (e *Echo) RunProcWithContext(ctx context.Context, cmdStr string) *exec.Proc {
+func (e *Session) RunProcWithContext(ctx context.Context, cmdStr string) *exec.Proc {
 	return exec.RunProcWithContextVars(ctx, cmdStr, e.vars)
 }
 
 // RunProc executes command in cmdStr and waits for the result.
 // It returns a *Proc with information about the executed process.
-func (e *Echo) RunProc(cmdStr string) *exec.Proc {
+func (e *Session) RunProc(cmdStr string) *exec.Proc {
 	return exec.RunProcWithContextVars(context.Background(), cmdStr, e.vars)
 }
 
 // Run executes cmdStr, with given context, and returns the result as a string.
-func (e *Echo) RunWithContext(ctx context.Context, cmdStr string) string {
+func (e *Session) RunWithContext(ctx context.Context, cmdStr string) string {
 	return exec.RunWithContextVars(ctx, cmdStr, e.vars)
 }
 
 // Run executes cmdStr, waits, and returns the result as a string.
-func (e *Echo) Run(cmdStr string) string {
+func (e *Session) Run(cmdStr string) string {
 	return exec.RunWithContextVars(context.Background(), cmdStr, e.vars)
 }
 
 // Runout executes command cmdStr and prints out the result
-func (e *Echo) Runout(cmdStr string) {
+func (e *Session) Runout(cmdStr string) {
 	fmt.Print(e.Run(cmdStr))
 }
 
 // Commands creates a *exe.CommandBuilder, with the specified context, to build a multi-command execution flow.
-func (e *Echo) CommandsWithContext(ctx context.Context, cmdStrs ...string) *exec.CommandBuilder {
+func (e *Session) CommandsWithContext(ctx context.Context, cmdStrs ...string) *exec.CommandBuilder {
 	return exec.CommandsWithContextVars(ctx, e.vars, cmdStrs...)
 }
 
 // Commands returns a *exe.CommandBuilder to build a multi-command execution flow.
-func (e *Echo) Commands(cmdStrs ...string) *exec.CommandBuilder {
+func (e *Session) Commands(cmdStrs ...string) *exec.CommandBuilder {
 	return exec.CommandsWithContextVars(context.Background(), e.vars, cmdStrs...)
 }
 
 // StartAllWithContext uses the specified ctx to start sequential execution of each command, in cmdStrs, and does not
 // wait for their completion.
-func (e *Echo) StartAllWithContext(ctx context.Context, cmdStrs ...string) *exec.CommandResult {
+func (e *Session) StartAllWithContext(ctx context.Context, cmdStrs ...string) *exec.CommandResult {
 	return exec.CommandsWithContextVars(ctx, e.vars, cmdStrs...).Start()
 }
 
 // StartAll starts the sequential execution of each command, in cmdStrs, and does not
 // wait for their completion.
-func (e *Echo) StartAll(cmdStrs ...string) *exec.CommandResult {
+func (e *Session) StartAll(cmdStrs ...string) *exec.CommandResult {
 	return exec.CommandsWithContextVars(context.Background(), e.vars, cmdStrs...).Start()
 }
 
 // RunAllWithContext executes each command sequentially, in cmdStrs, and wait for their completion.
-func (e *Echo) RunAllWithContext(ctx context.Context, cmdStrs ...string) *exec.CommandResult {
+func (e *Session) RunAllWithContext(ctx context.Context, cmdStrs ...string) *exec.CommandResult {
 	return exec.CommandsWithContextVars(ctx, e.vars, cmdStrs...).Run()
 }
 
 // RunAll executes each command sequentially, in cmdStrs, and wait for their completion.
-func (e *Echo) RunAll(cmdStrs ...string) *exec.CommandResult {
+func (e *Session) RunAll(cmdStrs ...string) *exec.CommandResult {
 	return exec.CommandsWithContextVars(context.Background(), e.vars, cmdStrs...).Run()
 }
 
 // StartConcurWithContext uses specified context to start the concurrent execution of each command, in cmdStrs, and does not
 // wait for their completion.
-func (e *Echo) StartConcurWithContext(ctx context.Context, cmdStrs ...string) *exec.CommandResult {
+func (e *Session) StartConcurWithContext(ctx context.Context, cmdStrs ...string) *exec.CommandResult {
 	return exec.CommandsWithContextVars(ctx, e.vars, cmdStrs...).Concurr()
 }
 
 // StartConcur starts the concurrent execution of each command, in cmdStrs, and does not
 // wait for their completion.
-func (e *Echo) StartConcur(cmdStrs ...string) *exec.CommandResult {
+func (e *Session) StartConcur(cmdStrs ...string) *exec.CommandResult {
 	return exec.CommandsWithContextVars(context.Background(), e.vars, cmdStrs...).Concurr()
 }
 
 // RunConcurWithContext uses context to execute each command concurrently, in cmdStrs, and waits
 // their completion.
-func (e *Echo) RunConcurWithContext(ctx context.Context, cmdStrs ...string) *exec.CommandResult {
+func (e *Session) RunConcurWithContext(ctx context.Context, cmdStrs ...string) *exec.CommandResult {
 	return exec.CommandsWithContextVars(ctx, e.vars, cmdStrs...).Concurr().Wait()
 }
 
 // RunConcur executes each command concurrently, in cmdStrs, and waits
 // their completion.
-func (e *Echo) RunConcur(cmdStrs ...string) *exec.CommandResult {
+func (e *Session) RunConcur(cmdStrs ...string) *exec.CommandResult {
 	return exec.CommandsWithContextVars(context.Background(), e.vars, cmdStrs...).Concurr().Wait()
 }
 
 // Pipe uses specified context to execute each command, in cmdStrs, by piping the result
 // of the previous command as input to the next command until done.
-func (e *Echo) PipeWithContext(ctx context.Context, cmdStrs ...string) *exec.PipedCommandResult {
+func (e *Session) PipeWithContext(ctx context.Context, cmdStrs ...string) *exec.PipedCommandResult {
 	return exec.CommandsWithContextVars(ctx, e.vars, cmdStrs...).Pipe()
 }
 
 // Pipe executes each command, in cmdStrs, by piping the result
 // of the previous command as input to the next command until done.
-func (e *Echo) Pipe(cmdStrs ...string) *exec.PipedCommandResult {
+func (e *Session) Pipe(cmdStrs ...string) *exec.PipedCommandResult {
 	return exec.CommandsWithContextVars(context.Background(), e.vars, cmdStrs...).Pipe()
 }
 
 // ParseCommand parses the string into individual command tokens
-func (e *Echo) ParseCommand(cmdStr string) (cmdName string, args []string) {
+func (e *Session) ParseCommand(cmdStr string) (cmdName string, args []string) {
 	result, err := exec.Parse(e.vars.Eval(cmdStr))
 	if err != nil {
 		e.err = err

--- a/procs_test.go
+++ b/procs_test.go
@@ -17,7 +17,7 @@ func TestEchoRun(t *testing.T) {
 			name:   "start proc",
 			cmdStr: `echo "HELLO WORLD!"`,
 			exec: func(t *testing.T, cmd string) {
-				p := DefaultEcho.StartProc(cmd)
+				p := DefaultSession.StartProc(cmd)
 				if p.Err() != nil {
 					t.Fatal("Unexpected error:", p.Err().Error())
 				}
@@ -50,7 +50,7 @@ func TestEchoRun(t *testing.T) {
 			name:   "start proc/long-running",
 			cmdStr: `/bin/sh -c "for i in {1..3}; do echo 'HELLO WORLD!\$i'; sleep 0.2; done"`,
 			exec: func(t *testing.T, cmd string) {
-				p := DefaultEcho.StartProc(cmd)
+				p := DefaultSession.StartProc(cmd)
 				if p.Err() != nil {
 					t.Fatal(p.Err())
 				}
@@ -68,7 +68,7 @@ func TestEchoRun(t *testing.T) {
 			name:   "run proc",
 			cmdStr: `echo "HELLO WORLD!"`,
 			exec: func(t *testing.T, cmd string) {
-				p := DefaultEcho.RunProc(cmd)
+				p := DefaultSession.RunProc(cmd)
 				if p.ExitCode() != 0 {
 					t.Fatal("Expecting exit code 0, got:", p.ExitCode())
 				}
@@ -84,7 +84,7 @@ func TestEchoRun(t *testing.T) {
 			name:   "simple run",
 			cmdStr: `echo "HELLO WORLD!"`,
 			exec: func(t *testing.T, cmd string) {
-				result := DefaultEcho.Run(cmd)
+				result := DefaultSession.Run(cmd)
 				if result != "HELLO WORLD!" {
 					t.Fatal("Unexpected command result:", result)
 				}
@@ -95,9 +95,9 @@ func TestEchoRun(t *testing.T) {
 			name:   "simple with expansion",
 			cmdStr: "echo $MSG",
 			exec: func(t *testing.T, cmd string) {
-				DefaultEcho.Variables().Vars("MSG=Hello World")
-				result := DefaultEcho.Run(cmd)
-				if result != DefaultEcho.Variables().Val("MSG") {
+				DefaultSession.Variables().Vars("MSG=Hello World")
+				result := DefaultSession.Run(cmd)
+				if result != DefaultSession.Variables().Val("MSG") {
 					t.Fatal("Unexpected command result:", result)
 				}
 			},

--- a/prog.go
+++ b/prog.go
@@ -5,11 +5,11 @@ import (
 )
 
 // Prog makes info available about currently executing program
-func (e *Echo) Prog() *prog.Info {
+func (e *Session) Prog() *prog.Info {
 	return e.prog
 }
 
 // Workdir returns the current program's working directory
-func (e *Echo) Workdir() string {
+func (e *Session) Workdir() string {
 	return e.Prog().Workdir()
 }

--- a/str.go
+++ b/str.go
@@ -3,6 +3,6 @@ package gexe
 import "github.com/vladimirvivien/gexe/str"
 
 // String creates a new str.Str value with string manipulation methods
-func (e *Echo) String(s string) *str.Str {
+func (e *Session) String(s string) *str.Str {
 	return str.StringWithVars(s, e.vars)
 }

--- a/variables.go
+++ b/variables.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Variables returns the variable mapping for echo session e
-func (e *Echo) Variables() *vars.Variables {
+func (e *Session) Variables() *vars.Variables {
 	return e.vars
 }
 
@@ -16,14 +16,14 @@ func (e *Echo) Variables() *vars.Variables {
 //
 // Environment vars can be used in string values
 // using Eval("building for os=$GOOS")
-func (e *Echo) Envs(variables ...string) *Echo {
+func (e *Session) Envs(variables ...string) *Session {
 	vars := e.vars.Envs(variables...)
 	e.err = vars.Err()
 	return e
 }
 
 // SetEnv sets a global process environment variable.
-func (e *Echo) SetEnv(name, value string) *Echo {
+func (e *Session) SetEnv(name, value string) *Session {
 	vars := e.vars.SetEnv(name, value)
 	e.err = vars.Err()
 	return e
@@ -36,34 +36,34 @@ func (e *Echo) SetEnv(name, value string) *Echo {
 //
 // Note that session vars are only available
 // for the running process.
-func (e *Echo) Vars(variables ...string) *Echo {
+func (e *Session) Vars(variables ...string) *Session {
 	vars := e.vars.Vars(variables...)
 	e.err = vars.Err()
 	return e
 }
 
 // SetVar declares a session variable.
-func (e *Echo) SetVar(name, value string) *Echo {
+func (e *Session) SetVar(name, value string) *Session {
 	vars := e.vars.SetVar(name, value)
 	e.err = vars.Err()
 	return e
 }
 
 // UnsetVar removes a session variable.
-func (e *Echo) UnsetVar(name string) *Echo {
+func (e *Session) UnsetVar(name string) *Session {
 	vars := e.vars.UnsetVar(name)
 	e.err = vars.Err()
 	return e
 }
 
 // Val retrieves a session or environment variable
-func (e *Echo) Val(name string) string {
+func (e *Session) Val(name string) string {
 	return e.vars.Val(name)
 }
 
 // Eval returns the string str with its content expanded
 // with variable values i.e. Eval("I am $HOME") returns
 // "I am </user/home/path>"
-func (e *Echo) Eval(str string) string {
+func (e *Session) Eval(str string) string {
 	return e.vars.Eval(str)
 }

--- a/variables_test.go
+++ b/variables_test.go
@@ -7,18 +7,18 @@ import (
 func TestEchoVar(t *testing.T) {
 	tests := []struct {
 		name string
-		echo func() *Echo
-		test func(*testing.T, *Echo)
+		echo func() *Session
+		test func(*testing.T, *Session)
 	}{
 		{
 			name: "SetVar",
-			echo: func() *Echo {
+			echo: func() *Session {
 				e := New()
 				e.SetVar("foo", "bar")
 				e.SetVar("fuzz", "buzz")
 				return e
 			},
-			test: func(t *testing.T, e *Echo) {
+			test: func(t *testing.T, e *Session) {
 				if e.Val("foo") != "bar" {
 					t.Fatal("unexpected value:", e.Val("foo"))
 				}
@@ -29,12 +29,12 @@ func TestEchoVar(t *testing.T) {
 		},
 		{
 			name: "Vars multiple",
-			echo: func() *Echo {
+			echo: func() *Session {
 				e := New()
 				e.Vars("foo=bar", "fuzz=buzz")
 				return e
 			},
-			test: func(t *testing.T, e *Echo) {
+			test: func(t *testing.T, e *Session) {
 				if e.Val("foo") != "bar" {
 					t.Fatal("unexpected value:", e.Val("foo"))
 				}
@@ -45,12 +45,12 @@ func TestEchoVar(t *testing.T) {
 		},
 		{
 			name: "Vars with quoted",
-			echo: func() *Echo {
+			echo: func() *Session {
 				e := New()
 				e.Vars("bazz=azz", `foo="bar"`, `fuzz='buzz'`)
 				return e
 			},
-			test: func(t *testing.T, e *Echo) {
+			test: func(t *testing.T, e *Session) {
 				if e.Val("bazz") != "azz" {
 					t.Fatal("unexpected value:", e.Val("bazz"))
 				}
@@ -64,13 +64,13 @@ func TestEchoVar(t *testing.T) {
 		},
 		{
 			name: "Vars with expansion",
-			echo: func() *Echo {
+			echo: func() *Session {
 				e := New()
 				e.SetVar("bazz", "dazz")
 				e.Vars("foo=${bazz}", "fuzz=buzz")
 				return e
 			},
-			test: func(t *testing.T, e *Echo) {
+			test: func(t *testing.T, e *Session) {
 				if e.Val("foo") != "dazz" {
 					t.Fatal("unexpected value:", e.Val("foo"))
 				}
@@ -81,13 +81,13 @@ func TestEchoVar(t *testing.T) {
 		},
 		{
 			name: "Vars overwrite Env",
-			echo: func() *Echo {
+			echo: func() *Session {
 				e := New()
 				e.SetVar("foo", "bar")
 				e.SetEnv("foo", "fuzz")
 				return e
 			},
-			test: func(t *testing.T, e *Echo) {
+			test: func(t *testing.T, e *Session) {
 				if e.Val("foo") != "bar" {
 					t.Fatal("unexpected value:", e.Val("foo"))
 				}
@@ -105,18 +105,18 @@ func TestEchoVar(t *testing.T) {
 func TestEchoEnv(t *testing.T) {
 	tests := []struct {
 		name string
-		echo func() *Echo
-		test func(*Echo)
+		echo func() *Session
+		test func(*Session)
 	}{
 		{
 			name: "SetEnv",
-			echo: func() *Echo {
+			echo: func() *Session {
 				e := New()
 				e.SetEnv("foo", "bar")
 				e.SetEnv("fuzz", "buzz")
 				return e
 			},
-			test: func(e *Echo) {
+			test: func(e *Session) {
 				if e.Val("foo") != "bar" {
 					t.Fatal("unexpected value:", e.Val("foo"))
 				}
@@ -127,12 +127,12 @@ func TestEchoEnv(t *testing.T) {
 		},
 		{
 			name: "Envs",
-			echo: func() *Echo {
+			echo: func() *Session {
 				e := New()
 				e.Envs("foo=bar", "fuzz=buzz")
 				return e
 			},
-			test: func(e *Echo) {
+			test: func(e *Session) {
 				if e.Val("foo") != "bar" {
 					t.Fatal("unexpected value:", e.Val("foo"))
 				}
@@ -143,12 +143,12 @@ func TestEchoEnv(t *testing.T) {
 		},
 		{
 			name: "Envs quoated",
-			echo: func() *Echo {
+			echo: func() *Session {
 				e := New()
 				e.Envs("bazz=azz", `foo="bar"`, `fuzz='buzz'`)
 				return e
 			},
-			test: func(e *Echo) {
+			test: func(e *Session) {
 				if e.Val("bazz") != "azz" {
 					t.Fatal("unexpected value:", e.Val("bazz"))
 				}
@@ -162,13 +162,13 @@ func TestEchoEnv(t *testing.T) {
 		},
 		{
 			name: "Env with expansion",
-			echo: func() *Echo {
+			echo: func() *Session {
 				e := New()
 				e.SetVar("bazz", "dazz")
 				e.Envs(`foo=${bazz}`, `fuzz=buzz`)
 				return e
 			},
-			test: func(e *Echo) {
+			test: func(e *Session) {
 				if e.Val("foo") != "dazz" && e.Val("fuzz") != "buzz" {
 					t.Fatal("unexpected value:", e.Val("foo"))
 				}
@@ -179,13 +179,13 @@ func TestEchoEnv(t *testing.T) {
 		},
 		{
 			name: "Env overwrite Vars",
-			echo: func() *Echo {
+			echo: func() *Session {
 				e := New()
 				e.SetVar("foo", "fuzz")
 				e.SetEnv("foo", "bar")
 				return e
 			},
-			test: func(e *Echo) {
+			test: func(e *Session) {
 				if e.Val("foo") != "fuzz" {
 					t.Fatal("unexpected value:", e.Val("foo"))
 				}


### PR DESCRIPTION
Introduces type `gexe.Session` to replace `gexe.Echo` to clean out reference of the old project name `Echo`.

Fixes #68 