### PR TITLE
Strings and Filepaths Joining

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -288,3 +288,31 @@ gexe.Run(`echo "Building OS: $GOOS; ARC: $GOARCH"`)
 gexe.SetEnv("GOOS","linux").SetEnv("GOARCH","amd64")
 gexe.Run(fmt.Sprintf(`echo "Building OS: %s ARC: %s"`, gexe.Val("GOOS"), gexe.Val("GOARCH")))
 ```
+
+---
+
+## String and Path Operations
+
+The `gexe` package provides convenient methods for joining strings and paths with automatic variable expansion.
+
+### Joining strings with variable expansion
+
+The `Join` method uses Go's `strings.Join` to concatenate strings with a specified separator while applying variable expansion to each element:
+
+```go
+gexe.SetVar("USER", "john")
+gexe.SetVar("DOMAIN", "example.com")
+email := gexe.Join("@", "${USER}", "${DOMAIN}")
+fmt.Println(email) // Output: john@example.com
+```
+
+### Joining paths with variable expansion
+
+The `JoinPath` method uses Go's `filepath.Join` to construct file paths with OS-specific separators while applying variable expansion to each element:
+
+```go
+gexe.SetVar("HOME", "/home/user")
+gexe.SetVar("PROJECT", "myapp")
+configPath := gexe.JoinPath("${HOME}", "workspace", "${PROJECT}", "config", "settings.json")
+fmt.Println(configPath) 
+```

--- a/functions.go
+++ b/functions.go
@@ -294,3 +294,27 @@ func PrintTo(w io.Writer, format string, args ...interface{}) *Session {
 func Error(format string, args ...interface{}) error {
 	return DefaultSession.Error(format, args...)
 }
+
+// Join uses strings.Join to join arbitrary strings with a separator
+// while applying gexe variable expansion to each element.
+//
+// Example:
+//
+//	gexe.SetVar("HOME", "/home/user")
+//	result := gexe.Join(",", "${HOME}", "documents", "file.txt")
+//	// Returns: "/home/user,documents,file.txt"
+func Join(sep string, elem ...string) string {
+	return DefaultSession.Join(sep, elem...)
+}
+
+// JoinPath uses filepath.Join to join file paths using OS-specific path separators
+// while applying gexe variable expansion to each element.
+//
+// Example:
+//
+//	gexe.SetVar("HOME", "/home/user")
+//	path := gexe.JoinPath("${HOME}", "documents", "file.txt")
+//	// Returns: "/home/user/documents/file.txt" (Unix) or "C:\Users\user\documents\file.txt" (Windows)
+func JoinPath(elem ...string) string {
+	return DefaultSession.JoinPath(elem...)
+}

--- a/join.go
+++ b/join.go
@@ -1,0 +1,26 @@
+package gexe
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// Join uses strings.Join to join arbitrary strings with a separator
+// while applying gexe variable expansion to each element
+func (e *Session) Join(sep string, elem ...string) string {
+	expandedElems := make([]string, len(elem))
+	for i, element := range elem {
+		expandedElems[i] = e.vars.Eval(element)
+	}
+	return strings.Join(expandedElems, sep)
+}
+
+// JoinPath uses filepath.Join to join file paths using OS-specific path separators
+// while applying gexe variable expansion to each element
+func (e *Session) JoinPath(elem ...string) string {
+	expandedElems := make([]string, len(elem))
+	for i, element := range elem {
+		expandedElems[i] = e.vars.Eval(element)
+	}
+	return filepath.Join(expandedElems...)
+}

--- a/join_test.go
+++ b/join_test.go
@@ -1,0 +1,123 @@
+//go:build !windows
+
+package gexe
+
+import (
+	"testing"
+)
+
+func TestJoin(t *testing.T) {
+	tests := []struct {
+		name      string
+		vars      map[string]string
+		separator string
+		elements  []string
+		expected  string
+	}{
+		{
+			name:      "basic string join",
+			separator: ",",
+			elements:  []string{"apple", "banana", "cherry"},
+			expected:  "apple,banana,cherry",
+		},
+		{
+			name:      "join with single variable",
+			vars:      map[string]string{"FRUIT": "apple"},
+			separator: "-",
+			elements:  []string{"${FRUIT}", "banana", "cherry"},
+			expected:  "apple-banana-cherry",
+		},
+		{
+			name:      "join with multiple variables",
+			vars:      map[string]string{"FIRST": "hello", "SECOND": "world"},
+			separator: " ",
+			elements:  []string{"${FIRST}", "${SECOND}", "!"},
+			expected:  "hello world !",
+		},
+		{
+			name:      "join with empty separator",
+			vars:      map[string]string{"PREFIX": "test"},
+			separator: "",
+			elements:  []string{"${PREFIX}", "123", "suffix"},
+			expected:  "test123suffix",
+		},
+		{
+			name:      "empty elements",
+			separator: ",",
+			elements:  []string{},
+			expected:  "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := New()
+			for key, value := range test.vars {
+				g.SetVar(key, value)
+			}
+
+			result := g.Join(test.separator, test.elements...)
+			if result != test.expected {
+				t.Errorf("Join() = %q, expected %q", result, test.expected)
+			}
+		})
+	}
+}
+
+func TestJoinPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		vars     map[string]string
+		elements []string
+		expected string
+	}{
+		{
+			name:     "basic path join",
+			elements: []string{"home", "user", "documents"},
+			expected: "home/user/documents",
+		},
+		{
+			name:     "path with single variable",
+			vars:     map[string]string{"HOME": "/home/user"},
+			elements: []string{"${HOME}", "documents", "file.txt"},
+			expected: "/home/user/documents/file.txt",
+		},
+		{
+			name:     "path with multiple variables",
+			vars:     map[string]string{"ROOT": "/opt", "APP": "myapp"},
+			elements: []string{"${ROOT}", "${APP}", "config", "settings.json"},
+			expected: "/opt/myapp/config/settings.json",
+		},
+		{
+			name:     "relative path",
+			vars:     map[string]string{"DIR": "src"},
+			elements: []string{"${DIR}", "main", "main.go"},
+			expected: "src/main/main.go",
+		},
+		{
+			name:     "empty elements",
+			elements: []string{},
+			expected: "",
+		},
+		{
+			name:     "variable with nested path",
+			vars:     map[string]string{"NESTED": "some/nested/path"},
+			elements: []string{"root", "${NESTED}", "file.txt"},
+			expected: "root/some/nested/path/file.txt",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := New()
+			for key, value := range test.vars {
+				g.SetVar(key, value)
+			}
+
+			result := g.JoinPath(test.elements...)
+			if result != test.expected {
+				t.Errorf("JoinPath() = %q, expected %q", result, test.expected)
+			}
+		})
+	}
+}

--- a/join_windows_test.go
+++ b/join_windows_test.go
@@ -1,0 +1,69 @@
+package gexe
+
+import (
+	"testing"
+)
+
+func TestJoinPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		vars     map[string]string
+		elements []string
+		expected string
+	}{
+		{
+			name:     "basic path join",
+			elements: []string{"home", "user", "documents"},
+			expected: "home\\user\\documents",
+		},
+		{
+			name:     "path with single variable",
+			vars:     map[string]string{"HOME": "C:\\Users\\user"},
+			elements: []string{"${HOME}", "documents", "file.txt"},
+			expected: "C:\\Users\\user\\documents\\file.txt",
+		},
+		{
+			name:     "path with multiple variables",
+			vars:     map[string]string{"ROOT": "C:\\Program Files", "APP": "myapp"},
+			elements: []string{"${ROOT}", "${APP}", "config", "settings.json"},
+			expected: "C:\\Program Files\\myapp\\config\\settings.json",
+		},
+		{
+			name:     "relative path",
+			vars:     map[string]string{"DIR": "src"},
+			elements: []string{"${DIR}", "main", "main.go"},
+			expected: "src\\main\\main.go",
+		},
+		{
+			name:     "empty elements",
+			elements: []string{},
+			expected: "",
+		},
+		{
+			name:     "variable with nested path",
+			vars:     map[string]string{"NESTED": "some\\nested\\path"},
+			elements: []string{"root", "${NESTED}", "file.txt"},
+			expected: "root\\some\\nested\\path\\file.txt",
+		},
+		{
+			name:     "drive letter paths",
+			vars:     map[string]string{"DRIVE": "D:\\", "FOLDER": "data"},
+			elements: []string{"${DRIVE}", "${FOLDER}", "files", "test.txt"},
+			expected: "D:\\data\\files\\test.txt",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := New()
+			for key, value := range test.vars {
+				g.SetVar(key, value)
+			}
+
+			result := g.JoinPath(test.elements...)
+			if result != test.expected {
+				t.Errorf("JoinPath() = %q, expected %q", result, test.expected)
+			}
+		})
+	}
+}

--- a/session.go
+++ b/session.go
@@ -28,7 +28,7 @@ type Session struct {
 	prog *prog.Info
 }
 
-// New creates a new Echo session
+// New creates a new Gexe session
 func New() *Session {
 	e := &Session{
 		vars: vars.New(),


### PR DESCRIPTION
Add String and Path Joining Methods with Variable Expansion

  Summary

This PR adds two new methods to the gexe Session type for joining strings and file paths with automatic variable expansion: Join() and JoinPath(). These
  methods provide convenient ways to concatenate strings and construct cross-platform file paths while leveraging gexe's variable expansion capabilities.

  Features

  String Joining

```go
  gexe.SetVar("USER", "john")
  gexe.SetVar("DOMAIN", "example.com")
  email := gexe.Join("@", "${USER}", "${DOMAIN}")
  // Returns: "john@example.com"
```

  Path Joining with Cross-Platform Support
```go
  gexe.SetVar("HOME", "/home/user")
  gexe.SetVar("PROJECT", "myapp")
  path := gexe.JoinPath("${HOME}", "workspace", "${PROJECT}", "config")
  // Unix: "/home/user/workspace/myapp/config"
  // Windows: "C:\Users\user\workspace\myapp\config"
```

Fixes #74 